### PR TITLE
Fix equal objects issue

### DIFF
--- a/plugins/module_utils/configuration.py
+++ b/plugins/module_utils/configuration.py
@@ -27,7 +27,7 @@ from functools import partial
 
 from ansible.module_utils.six import iteritems
 
-from ansible_collections.cisco.fmcansible.plugins.module_utils.common import HTTPMethod, equal_objects_additive, FmcConfigurationError, \
+from ansible_collections.cisco.fmcansible.plugins.module_utils.common import HTTPMethod, equal_objects, equal_objects_additive, FmcConfigurationError, \
     FmcServerError, ResponseParams, copy_identity_properties, FmcUnexpectedResponse
 from ansible_collections.cisco.fmcansible.plugins.module_utils.fmc_swagger_client import OperationField, ValidationError
 # from module_utils.common import HTTPMethod, equal_objects, FmcConfigurationError, FmcServerError, ResponseParams, \

--- a/plugins/module_utils/configuration.py
+++ b/plugins/module_utils/configuration.py
@@ -27,7 +27,7 @@ from functools import partial
 
 from ansible.module_utils.six import iteritems
 
-from ansible_collections.cisco.fmcansible.plugins.module_utils.common import HTTPMethod, equal_objects, FmcConfigurationError, \
+from ansible_collections.cisco.fmcansible.plugins.module_utils.common import HTTPMethod, equal_objects_additive, FmcConfigurationError, \
     FmcServerError, ResponseParams, copy_identity_properties, FmcUnexpectedResponse
 from ansible_collections.cisco.fmcansible.plugins.module_utils.fmc_swagger_client import OperationField, ValidationError
 # from module_utils.common import HTTPMethod, equal_objects, FmcConfigurationError, FmcServerError, ResponseParams, \
@@ -404,8 +404,9 @@ class BaseConfigurationResource(object):
 
         if existing_list_obj is not None:
             # get full existing object
+            playbook_obj = params[ParamName.DATA]
             existing_obj = self._find_existing_object(model_name, params[ParamName.PATH_PARAMS], existing_list_obj['id'])
-            if are_objects_equal(existing_obj, params[ParamName.DATA]):
+            if is_playbook_obj_equal_to_api_obj(playbook_obj, existing_obj):
                 return existing_obj
             else:
                 raise FmcConfigurationError(DUPLICATE_ERROR, existing_obj)
@@ -479,7 +480,7 @@ class BaseConfigurationResource(object):
         existing_object = self._find_existing_object(model_name, path_params, objectId)
         if not existing_object:
             raise FmcConfigurationError(NOT_EXISTS_ERROR_STR)
-        elif are_objects_equal(existing_object, data):
+        elif is_playbook_obj_equal_to_api_obj(data, existing_object):
             return existing_object
 
         return self.send_general_request(operation_name, params)
@@ -687,13 +688,13 @@ def iterate_over_pageable_resource(resource_func, params):
         query_params['offset'] = int(query_params['offset']) + limit
 
 
-def are_objects_equal(obj1, obj2):
+def is_playbook_obj_equal_to_api_obj(obj_client, obj_server):
     """
     Wrapper call to equal_objects(), strips type from obj1 first since type names will be slightly different
     based on origin from FMC API.
     """
     # because FMC can be inconsistent on type name, remove from source dict for comparison
-    d1 = obj1.copy()
-    d1.pop('type', '')
-    d2 = obj2
-    return equal_objects(d1, d2)
+    # d1 = obj1.copy()
+    # d1.pop('type', '')
+    # d2 = obj2
+    return equal_objects_additive(obj_client, obj_server)

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -291,6 +291,7 @@ def test_equal_objects_return_true_with_reference_list_containing_duplicates():
         }
     )
 
+
 def test_equal_objects_additive_sanity():
     assert equal_objects_additive(
         {
@@ -302,6 +303,7 @@ def test_equal_objects_additive_sanity():
             'bar': 2
         }
     )
+
 
 def test_equal_objects_additive_leftside():
     # false: left side has properties not on right side
@@ -315,6 +317,7 @@ def test_equal_objects_additive_leftside():
         }
     )
 
+
 def test_equal_objects_additive_rightside():
     # true: right side has properties not on right side, this is okay
     assert not equal_objects_additive(
@@ -326,6 +329,7 @@ def test_equal_objects_additive_rightside():
             'bar': 2
         }
     )
+
 
 def test_equal_objects_additive_objects():
     # false: left side has object properties not on right side
@@ -368,6 +372,7 @@ def test_equal_objects_additive_objects():
             }
         }
     )
+
 
 def test_delete_ref_duplicates_with_none():
     assert delete_ref_duplicates(None) is None

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -20,7 +20,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible_collections.cisco.fmcansible.plugins.module_utils.common import equal_objects, equal_objects_additive, delete_ref_duplicates, construct_ansible_facts
+from ansible_collections.cisco.fmcansible.plugins.module_utils.common import equal_objects, equal_objects_additive, delete_ref_duplicates, \
+    construct_ansible_facts
 
 
 # simple objects
@@ -320,7 +321,7 @@ def test_equal_objects_additive_leftside():
 
 def test_equal_objects_additive_rightside():
     # true: right side has properties not on right side, this is okay
-    assert not equal_objects_additive(
+    assert equal_objects_additive(
         {
             'foo': 1
         },

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -291,6 +291,83 @@ def test_equal_objects_return_true_with_reference_list_containing_duplicates():
         }
     )
 
+def test_equal_objects_additive_sanity():
+    assert equal_objects(
+        {
+            'foo': 1,
+            'bar': 2
+        },
+        {
+            'foo': 1,
+            'bar': 2
+        }
+    )
+
+def test_equal_objects_additive_leftside():
+    # false: left side has properties not on right side
+    assert not equal_objects(
+        {
+            'foo': 1,
+            'bar': 2
+        },
+        {
+            'foo': 1
+        }
+    )
+
+def test_equal_objects_additive_rightside():
+    # true: right side has properties not on right side, this is okay
+    assert not equal_objects(
+        {
+            'foo': 1
+        },
+        {
+            'foo': 1,
+            'bar': 2
+        }
+    )
+
+def test_equal_objects_additive_objects():
+    # false: left side has object properties not on right side
+    assert not equal_objects(
+        {
+            "name": "foo",
+            "action": "ALLOW",
+            "type": "AccessRule",
+            "sourceNetworks": {
+                "objects": [
+                    {
+                        "type": "Network",
+                        "name": "bar",
+                        "id": "123"
+                    }
+                ]
+            },
+            "destinationNetworks": {
+                "objects": [
+                    {
+                        "type": "Network",
+                        "name": "bax",
+                        "id": "456"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "foo",
+            "action": "ALLOW",
+            "type": "AccessRule",
+            "sourceNetworks": {
+                "objects": [
+                    {
+                        "type": "Network",
+                        "name": "bar",
+                        "id": "123"
+                    }
+                ]
+            }
+        }
+    )
 
 def test_delete_ref_duplicates_with_none():
     assert delete_ref_duplicates(None) is None

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible_collections.cisco.fmcansible.plugins.module_utils.common import equal_objects, delete_ref_duplicates, construct_ansible_facts
+from ansible_collections.cisco.fmcansible.plugins.module_utils.common import equal_objects, equal_objects_additive, delete_ref_duplicates, construct_ansible_facts
 
 
 # simple objects
@@ -292,7 +292,7 @@ def test_equal_objects_return_true_with_reference_list_containing_duplicates():
     )
 
 def test_equal_objects_additive_sanity():
-    assert equal_objects(
+    assert equal_objects_additive(
         {
             'foo': 1,
             'bar': 2
@@ -305,7 +305,7 @@ def test_equal_objects_additive_sanity():
 
 def test_equal_objects_additive_leftside():
     # false: left side has properties not on right side
-    assert not equal_objects(
+    assert not equal_objects_additive(
         {
             'foo': 1,
             'bar': 2
@@ -317,7 +317,7 @@ def test_equal_objects_additive_leftside():
 
 def test_equal_objects_additive_rightside():
     # true: right side has properties not on right side, this is okay
-    assert not equal_objects(
+    assert not equal_objects_additive(
         {
             'foo': 1
         },
@@ -329,7 +329,7 @@ def test_equal_objects_additive_rightside():
 
 def test_equal_objects_additive_objects():
     # false: left side has object properties not on right side
-    assert not equal_objects(
+    assert not equal_objects_additive(
         {
             "name": "foo",
             "action": "ALLOW",


### PR DESCRIPTION
Change equal objects compare behavior to be additive from left side to right, meaning if the playbook object has new properties not present on the API object, then the equality check fails, allowing the playbook task to make the API call to perform the update.