### PR TITLE
Fix object compare with missing id/name

### DIFF
--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -99,9 +99,13 @@ def is_object_ref(d):
     :type d: dict
     :return: True if passed dictionary is a reference object, otherwise False
     """
-    has_id = 'id' in d.keys() and d['id']
-    has_type = 'type' in d.keys() and d['type']
-    return has_id and has_type
+    has_id =  'id' in d.keys() and d['id']
+    return has_id
+    # commented out, types may not match between client and server due to formatting
+    # id is sufficient to compare
+    # has_id = 'id' in d.keys() and d['id']
+    # has_type = 'type' in d.keys() and d['type']
+    # return has_id # and has_type
 
 
 def equal_object_refs(d1, d2):
@@ -112,9 +116,12 @@ def equal_object_refs(d1, d2):
     :type d2: dict
     :return: True if passed references point to the same object, otherwise False
     """
+    # compare by type not supported, see is_object_ref()
     have_equal_ids = d1['id'] == d2['id']
-    have_equal_types = d1['type'] == d2['type']
-    return have_equal_ids and have_equal_types
+    have_equal_names = d1['name'] == d2['name']
+    return have_equal_ids or have_equal_names
+    # have_equal_types = d1['type'] == d2['type']
+    return have_equal_ids # and have_equal_types
 
 
 def equal_lists(l1, l2):
@@ -145,8 +152,12 @@ def equal_dicts(d1, d2, compare_by_reference=True):
     :param compare_by_reference: if True, dictionaries referencing objects are compared using `equal_object_refs` method
     :return: True if passed dicts are equal. Otherwise, returns False.
     """
-    if compare_by_reference and is_object_ref(d1) and is_object_ref(d2):
-        return equal_object_refs(d1, d2)
+    if compare_by_reference:
+        if is_object_ref(d1) and is_object_ref(d2):
+            return equal_object_refs(d1, d2)
+        elif is_object_ref(d2):
+            # if right side has id but not left side, compare common properties only
+            return equal_objects(d1, d2, True)
 
     if len(d1) != len(d2):
         return False
@@ -220,7 +231,7 @@ def equal_objects(d1, d2, compare_common_fields_only=True):
     return equal_dicts(d1, d2, compare_by_reference=False)
 
 
-def equal_objects_additive(d1, d2):
+def add_missing_properties_left_to_right(d1, d2):
     """
     Checks whether two objects are equal using the additive approach. This means that d1 can contain less
     properties than d2, but not vice versa. Similar to equal_objects() except compare_common_fields_only
@@ -232,15 +243,19 @@ def equal_objects_additive(d1, d2):
     """
     additive_keys = d1.keys()
     d2_keys = d2.keys()
-    d2 = dict(d2)
-    # copy empty values to right side before comparison
+    # d2 = dict(d2)
+    # copy empty values to right side recursively before comparison
     # this will force equal_objects() to false if left side has more properties
     for key in additive_keys:
         if key not in d2_keys:
-            new_obj = empty_value(d1[key])
+            # special case: name - if in d1 and not in d2, then ignore (set d2 so they match)
+            if key == "name":
+                new_obj = d1[key]
+            else:
+                new_obj = empty_value(d1[key])
             d2[key] = new_obj
-    # now compare additive object with right-side object
-    return equal_objects(d1, d2, True)
+        elif type(d1[key]) == dict and type(d2[key]) == dict:
+            add_missing_properties_left_to_right(d1[key], d2[key])
 
 
 def empty_value(val):
@@ -291,3 +306,18 @@ def delete_ref_duplicates(d):
         else:
             modified_d[k] = v
     return modified_d
+
+
+def delete_props_not_in_model(obj, model):
+    """
+    Deletes properties from an object that do not match its corresponding model
+    """
+    obj_to_check = dict(obj)
+    # remove properties from obj_client not in model
+    props = model.get("properties")
+    if props is None:
+        return obj
+    for key in obj:
+        if key not in props:
+            del obj_to_check[key]
+    return obj_to_check

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -99,7 +99,7 @@ def is_object_ref(d):
     :type d: dict
     :return: True if passed dictionary is a reference object, otherwise False
     """
-    has_id =  'id' in d.keys() and d['id']
+    has_id = 'id' in d.keys() and d['id']
     return has_id
     # commented out, types may not match between client and server due to formatting
     # id is sufficient to compare
@@ -117,11 +117,10 @@ def equal_object_refs(d1, d2):
     :return: True if passed references point to the same object, otherwise False
     """
     # compare by type not supported, see is_object_ref()
-    have_equal_ids = d1['id'] == d2['id']
-    have_equal_names = d1['name'] == d2['name']
-    return have_equal_ids or have_equal_names
+    have_equal_ids = d1.get('id') == d2.get('id')
+    # have_equal_names = d1.get('name') == d2.get('name')
+    return have_equal_ids
     # have_equal_types = d1['type'] == d2['type']
-    return have_equal_ids # and have_equal_types
 
 
 def equal_lists(l1, l2):
@@ -156,7 +155,7 @@ def equal_dicts(d1, d2, compare_by_reference=True):
         if is_object_ref(d1) and is_object_ref(d2):
             return equal_object_refs(d1, d2)
         elif is_object_ref(d2):
-            # if right side has id but not left side, compare common properties only
+            # if right side (from server) has id but not left side, compare common properties only
             return equal_objects(d1, d2, True)
 
     if len(d1) != len(d2):

--- a/plugins/module_utils/configuration.py
+++ b/plugins/module_utils/configuration.py
@@ -384,7 +384,7 @@ class BaseConfigurationResource(object):
             # note: FMC normally returns 400 for duplicates, but sometimes 422
             return (err.code == BAD_REQUEST_STATUS or err.code == UNPROCESSABLE_ENTITY_STATUS) \
                 and DUPLICATE_NAME_ERROR_STR in str(err)
-                
+
         is_bulk = self.is_bulk_operation(params)
         # for bulk operation, skip equality check since there are multiple
         if is_bulk:
@@ -419,7 +419,7 @@ class BaseConfigurationResource(object):
 
         For FMC, this function only supports checking against a single object.
         """
-        model_name = self.get_operation_spec(operation_name)[OperationField.MODEL_NAME]
+        model_name = self.get_operation_spec(operation_name).get(OperationField.MODEL_NAME)
         # get list object first - this only contains id, name, type
         existing_list_obj = self._find_object_matching_params(model_name, params)
 

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -113,9 +113,10 @@ def test_equal_objects_return_true_with_different_ref_ids():
 
 
 def test_equal_objects_return_true_with_only_right_ref_id():
-    assert not equal_objects(
-        {'foo': {'name': 'network-1'}},
-        {'foo': {'id': '1', 'name': 'network-1'}}
+    # because id missing from server obj, compare on common properties
+    assert equal_objects(
+        {'foo': {'name': 'network-1', 'some_val': 3}},
+        {'foo': {'id': '1', 'name': 'network-1', 'some_val': 3}}
     )
 
 

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -112,10 +112,10 @@ def test_equal_objects_return_true_with_different_ref_ids():
     )
 
 
-def test_equal_objects_return_true_with_different_ref_types():
+def test_equal_objects_return_true_with_only_right_ref_id():
     assert not equal_objects(
-        {'foo': {'id': '1', 'type': 'network', 'ignored_field': 'foo'}},
-        {'foo': {'id': '1', 'type': 'accessRule', 'ignored_field': 'bar'}}
+        {'foo': {'name': 'network-1'}},
+        {'foo': {'id': '1', 'name': 'network-1'}}
     )
 
 

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -20,8 +20,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible_collections.cisco.fmcansible.plugins.module_utils.common import equal_objects, equal_objects_additive, delete_ref_duplicates, \
-    construct_ansible_facts
+from ansible_collections.cisco.fmcansible.plugins.module_utils.common import equal_objects, add_missing_properties_left_to_right, \
+    construct_ansible_facts, delete_ref_duplicates
 
 
 # simple objects
@@ -293,86 +293,84 @@ def test_equal_objects_return_true_with_reference_list_containing_duplicates():
     )
 
 
-def test_equal_objects_additive_sanity():
-    assert equal_objects_additive(
-        {
-            'foo': 1,
-            'bar': 2
-        },
-        {
-            'foo': 1,
-            'bar': 2
-        }
-    )
+def test_add_missing_properties_left_to_right_sanity():
+    d1 = {
+        'foo': 1,
+        'bar': 2
+    }
+    d2 = dict(d1)
+    add_missing_properties_left_to_right(d1, d2)
+    assert d1 == d2
 
 
-def test_equal_objects_additive_leftside():
-    # false: left side has properties not on right side
-    assert not equal_objects_additive(
-        {
-            'foo': 1,
-            'bar': 2
-        },
-        {
-            'foo': 1
-        }
-    )
+def test_add_missing_properties_left_to_right_leftside():
+    # left side has properties not on right side, copied as empty properties
+    d1 = {
+        'foo': 1,
+        'bar': 2
+    }
+    d2 = {
+        'foo': 1
+    }
+    add_missing_properties_left_to_right(d1, d2)
+    assert d2.get('bar') and d2.get('bar') == 0
 
 
-def test_equal_objects_additive_rightside():
-    # true: right side has properties not on right side, this is okay
-    assert equal_objects_additive(
-        {
-            'foo': 1
-        },
-        {
-            'foo': 1,
-            'bar': 2
-        }
-    )
+def test_add_missing_properties_left_to_right_rightside():
+    # right side has properties not on right side, nothing copied
+    d1 = {
+        'foo': 1
+    }
+    d2 = {
+        'foo': 1,
+        'bar': 2
+    }
+    add_missing_properties_left_to_right(d1, d2)
+    assert d1.get('bar') is None
 
 
-def test_equal_objects_additive_objects():
+def test_add_missing_properties_left_to_right_complex_objects():
     # false: left side has object properties not on right side
-    assert not equal_objects_additive(
-        {
-            "name": "foo",
-            "action": "ALLOW",
-            "type": "AccessRule",
-            "sourceNetworks": {
-                "objects": [
-                    {
-                        "type": "Network",
-                        "name": "bar",
-                        "id": "123"
-                    }
-                ]
-            },
-            "destinationNetworks": {
-                "objects": [
-                    {
-                        "type": "Network",
-                        "name": "bax",
-                        "id": "456"
-                    }
-                ]
-            }
+    d1 = {
+        "name": "foo",
+        "action": "ALLOW",
+        "type": "AccessRule",
+        "sourceNetworks": {
+            "objects": [
+                {
+                    "type": "Network",
+                    "name": "bar",
+                    "id": "123"
+                }
+            ]
         },
-        {
-            "name": "foo",
-            "action": "ALLOW",
-            "type": "AccessRule",
-            "sourceNetworks": {
-                "objects": [
-                    {
-                        "type": "Network",
-                        "name": "bar",
-                        "id": "123"
-                    }
-                ]
-            }
+        "destinationNetworks": {
+            "objects": [
+                {
+                    "type": "Network",
+                    "name": "bax",
+                    "id": "456"
+                }
+            ]
         }
-    )
+    }
+    d2 = {
+        "name": "foo",
+        "action": "ALLOW",
+        "type": "AccessRule",
+        "sourceNetworks": {
+            "objects": [
+                {
+                    "type": "Network",
+                    "name": "bar",
+                    "id": "123"
+                }
+            ]
+        }
+    }
+    add_missing_properties_left_to_right(d1, d2)
+    assert type(d2.get('destinationNetworks')) == dict
+    assert len(d2.get('destinationNetworks')) == 0
 
 
 def test_delete_ref_duplicates_with_none():

--- a/tests/unit/module_utils/test_common.py
+++ b/tests/unit/module_utils/test_common.py
@@ -313,7 +313,7 @@ def test_add_missing_properties_left_to_right_leftside():
         'foo': 1
     }
     add_missing_properties_left_to_right(d1, d2)
-    assert d2.get('bar') and d2.get('bar') == 0
+    assert d2.get('bar') == 0
 
 
 def test_add_missing_properties_left_to_right_rightside():


### PR DESCRIPTION
- Fix create/createMultiple operations to do a duplicate check before sending request as some API calls do not return a 400/422 duplicate error (example: createMultipleFTDManualNatRule)
- Fix object compare for nested objects with id coming from server. These comparisons were failing because the client-side object has no id set in the task. When the id is missing it will now do a full object compare.
- Fix object compare when the server returns an object with no "name" property. Will now do a full object compare in that case.
- Use "ifname" property for interface objects for name comparison instead of "name" property (example: FTDSubInterface).