### PR TITLE
Fix for section query param

### DIFF
--- a/plugins/httpapi/client.py
+++ b/plugins/httpapi/client.py
@@ -84,7 +84,7 @@ class InternalHttpClient(object):
         # ex:
         #     connection.send(url, data, method=http_method, headers=BASE_HEADERS)
         method = method.upper()
-        conn = http.client.HTTPSConnection(self._host, timeout=10, context=ssl._create_unverified_context())
+        conn = http.client.HTTPSConnection(self._host, timeout=60, context=ssl._create_unverified_context())
         conn.request(method, url_path, data, headers)
         # response
         response = conn.getresponse()

--- a/plugins/module_utils/configuration.py
+++ b/plugins/module_utils/configuration.py
@@ -29,7 +29,7 @@ from ansible.module_utils.six import iteritems
 
 from ansible_collections.cisco.fmcansible.plugins.module_utils.common import HTTPMethod, equal_objects, delete_props_not_in_model, \
     FmcServerError, ResponseParams, copy_identity_properties, add_missing_properties_left_to_right, FmcUnexpectedResponse, FmcConfigurationError
-from ansible_collections.cisco.fmcansible.plugins.module_utils.fmc_swagger_client import OperationField, ValidationError
+from ansible_collections.cisco.fmcansible.plugins.module_utils.fmc_swagger_client import OperationField, OperationParams, ValidationError
 # from module_utils.common import HTTPMethod, equal_objects, FmcConfigurationError, FmcServerError, ResponseParams, \
 #   copy_identity_properties, FmcUnexpectedResponse
 # from module_utils.fmc_swagger_client import OperationField, ValidationError
@@ -552,6 +552,9 @@ class BaseConfigurationResource(object):
 
         data, query_params, path_params = _get_user_params(params)
         op_spec = self.get_operation_spec(operation_name)
+
+        query_params = {key: val for (key, val) in query_params.items() if key in op_spec[OperationField.PARAMETERS][OperationParams.QUERY].keys()}
+
         url, method = op_spec[OperationField.URL], op_spec[OperationField.METHOD]
 
         return self._send_request(url, method, data, path_params, query_params)


### PR DESCRIPTION
When the create function is being called in Issue#14. It's actually doing a GETALL request before to check if the access rule already exists because 2 rules with same names can't exist. While doing this request it's sending the section as query param which is unsupported by GET requests. Hence, the error.
Fix was to basically add a check before each request sent if the parameter exists as a valid parameter and then send it.