### PR TITLE
fix: removes comments and commit artifacts from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-<<<<<<< HEAD
 ansible>=2.10.7
 urllib3>=1.26.5
 lxml>=4.6.3
-=======
-#ansible==2.10.7
 ansible>=2.17.0
-#urllib3==1.26.5
-urllib3
-lxml==4.6.3
 requests>=2.25.0
->>>>>>> main


### PR DESCRIPTION
The git artifacts causes ansible-builder to fail while building an execution environment. Removing them will likely solve the problem. I am also removing some comments and duplicate package names
