### PR TITLE
Fix swagger free form object validation

### DIFF
--- a/plugins/module_utils/fmc_swagger_client.py
+++ b/plugins/module_utils/fmc_swagger_client.py
@@ -34,6 +34,8 @@ FILE_MODEL_NAME = '_File'
 SUCCESS_RESPONSE_CODE = '200'
 DELETE_PREFIX = 'delete'
 MODEL_LIST_SUFFIX = 'ListContainer'
+APPLICATION_JSON = 'application/json'
+REQUEST_EXAMPLE_PREFIX = 'request example'
 
 
 class OperationField:
@@ -43,6 +45,7 @@ class OperationField:
     MODEL_NAME = 'modelName'
     DESCRIPTION = 'description'
     RETURN_MULTIPLE_ITEMS = 'returnMultipleItems'
+    REQUEST_REQUIRED_FIELDS = 'requestRequiredFields'
     TAGS = "tags"
 
 
@@ -56,6 +59,7 @@ class SpecProp:
 class PropName:
     ADDITIONAL_PROPERTIES = 'additionalProperties'
     ENUM = 'enum'
+    EXAMPLES = 'examples'
     TYPE = 'type'
     REQUIRED = 'required'
     INVALID_TYPE = 'invalid_type'
@@ -219,9 +223,52 @@ class FmcSwaggerParser:
                 if OperationField.PARAMETERS in params:
                     operation[OperationField.PARAMETERS] = self._get_rest_params(params[OperationField.PARAMETERS], spec['parameters'])
 
+                request_required_fields = self._get_request_required_fields(
+                    method,
+                    params,
+                    operation[OperationField.MODEL_NAME],
+                )
+                if request_required_fields is not None:
+                    operation[OperationField.REQUEST_REQUIRED_FIELDS] = request_required_fields
+
                 operation_id = params[PropName.OPERATION_ID]
                 operations_dict[operation_id] = operation
         return operations_dict
+
+    def _get_request_required_fields(self, method, params, model_name):
+        if method not in (HTTPMethod.POST, HTTPMethod.PUT) or model_name is None:
+            return None
+
+        model_required_fields = self._definitions.get(model_name, {}).get(PropName.REQUIRED)
+        request_examples = self._get_request_examples(params)
+        if model_required_fields is None or not request_examples:
+            return None
+
+        request_fields = set(model_required_fields)
+        for example in request_examples:
+            request_fields.intersection_update(example.keys())
+
+        return [field for field in model_required_fields if field in request_fields]
+
+    @staticmethod
+    def _get_request_examples(params):
+        # FMC stores labeled request and response examples together under each
+        # response instead of placing request examples on the body parameter.
+        request_examples = []
+        for response in params.get(PropName.RESPONSES, {}).values():
+            examples = response.get(PropName.EXAMPLES, {}).get(APPLICATION_JSON, {})
+            if not isinstance(examples, dict):
+                continue
+
+            for title, example in examples.items():
+                if not isinstance(title, string_types) or not title.lower().startswith(REQUEST_EXAMPLE_PREFIX):
+                    continue
+                if isinstance(example, dict):
+                    request_examples.append(example)
+                elif isinstance(example, list):
+                    request_examples.extend(item for item in example if isinstance(item, dict))
+
+        return request_examples
 
     def _enrich_operations_with_docs(self, operations, docs):
         def get_operation_docs(op):
@@ -444,6 +491,9 @@ class FmcSwaggerValidator:
         operation = self._operations[operation_name]
         model_name = operation[OperationField.MODEL_NAME]
         model = self._models[model_name]
+        if OperationField.REQUEST_REQUIRED_FIELDS in operation:
+            model = dict(model)
+            model[PropName.REQUIRED] = operation[OperationField.REQUEST_REQUIRED_FIELDS]
         status = self._init_report()
 
         self._validate_root_object(status, model, data, '')

--- a/plugins/module_utils/fmc_swagger_client.py
+++ b/plugins/module_utils/fmc_swagger_client.py
@@ -54,6 +54,7 @@ class SpecProp:
 
 
 class PropName:
+    ADDITIONAL_PROPERTIES = 'additionalProperties'
     ENUM = 'enum'
     TYPE = 'type'
     REQUIRED = 'required'
@@ -643,7 +644,7 @@ class FmcSwaggerValidator:
         if PropName.REQUIRED in model:
             self._check_required_fields(status, model[PropName.REQUIRED], data, path)
 
-        model_properties = model[PropName.PROPERTIES]
+        model_properties = model.get(PropName.PROPERTIES) or {}
         for prop in model_properties.keys():
             if prop in data:
                 model_prop_val = model_properties[prop]
@@ -654,6 +655,19 @@ class FmcSwaggerValidator:
                     expected_type = PropType.OBJECT
                 actually_value = data[prop]
                 self._check_types(status, actually_value, expected_type, model_prop_val, path, prop)
+
+        additional_properties = model.get(PropName.ADDITIONAL_PROPERTIES)
+        if isinstance(additional_properties, dict):
+            if PropName.TYPE in additional_properties:
+                expected_type = additional_properties[PropName.TYPE]
+            elif PropName.REF in additional_properties:
+                expected_type = PropType.OBJECT
+            else:
+                return
+
+            for prop in data.keys():
+                if prop not in model_properties:
+                    self._check_types(status, data[prop], expected_type, additional_properties, path, prop)
 
     def _check_types(self, status, actually_value, expected_type, model, path, prop_name):
         if expected_type == PropType.OBJECT:

--- a/tests/unit/module_utils/test_fmc_swagger_parser.py
+++ b/tests/unit/module_utils/test_fmc_swagger_parser.py
@@ -244,6 +244,67 @@ class TestFmcSwaggerParser(unittest.TestCase):
         assert 'Description for offset field' == get_op_params['query']['offset']['description']
         assert '' == get_op_params['query']['limit']['description']
 
+    def test_request_examples_narrow_shared_model_required_fields(self):
+        api_spec = {
+            'definitions': {
+                'SharedModel': {
+                    'type': 'object',
+                    'required': ['requestField', 'serverGeneratedField'],
+                    'properties': {
+                        'requestField': {'type': 'string'},
+                        'serverGeneratedField': {'type': 'object'},
+                    },
+                },
+            },
+            'parameters': {},
+            'paths': {
+                '/objects': {
+                    'post': {
+                        'operationId': 'createSharedModel',
+                        'parameters': [{
+                            'in': 'body',
+                            'name': 'body',
+                            'schema': {'$ref': '#/definitions/SharedModel'},
+                        }],
+                        'responses': {
+                            '201': {
+                                'schema': {'$ref': '#/definitions/SharedModel'},
+                                'examples': {
+                                    'application/json': {
+                                        'Request example 1': {
+                                            'requestField': 'input',
+                                        },
+                                        'Response Example 1': {
+                                            'requestField': 'input',
+                                            'serverGeneratedField': {},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        parsed_spec = FmcSwaggerParser().parse_spec(api_spec)
+
+        assert ['requestField'] == parsed_spec['operations']['createSharedModel']['requestRequiredFields']
+
+    def test_response_examples_do_not_override_model_required_fields(self):
+        api_spec = copy.deepcopy(base)
+        api_spec['paths']['/object/networks']['post']['responses']['200']['examples'] = {
+            'application/json': {
+                'Response Example 1': {
+                    'type': 'Network',
+                },
+            },
+        }
+
+        parsed_spec = FmcSwaggerParser().parse_spec(api_spec)
+
+        assert 'requestRequiredFields' not in parsed_spec['operations']['addNetworkObject']
+
     def test_model_operations_should_contain_all_operations(self):
         data = {
             'basePath': '/v2/',

--- a/tests/unit/module_utils/test_fmc_swagger_validator.py
+++ b/tests/unit/module_utils/test_fmc_swagger_validator.py
@@ -893,6 +893,96 @@ class TestFmcSwaggerValidator(unittest.TestCase):
             }]
         } == rez
 
+    def test_operation_request_requirements_override_shared_model_requirements(self):
+        spec = {
+            'models': {
+                'SharedModel': {
+                    'type': 'object',
+                    'required': ['requestField', 'serverGeneratedField'],
+                    'properties': {
+                        'requestField': {'type': 'string'},
+                        'serverGeneratedField': {'type': 'object'},
+                    },
+                },
+            },
+            'operations': {
+                'createSharedModel': {
+                    'modelName': 'SharedModel',
+                    'requestRequiredFields': ['requestField'],
+                },
+            },
+        }
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data(
+            'createSharedModel',
+            {'requestField': 'input'},
+        )
+
+        assert valid
+        assert rez is None
+
+    def test_operation_request_requirements_remain_required(self):
+        spec = {
+            'models': {
+                'SharedModel': {
+                    'type': 'object',
+                    'required': ['requestField', 'serverGeneratedField'],
+                    'properties': {
+                        'requestField': {'type': 'string'},
+                        'serverGeneratedField': {'type': 'object'},
+                    },
+                },
+            },
+            'operations': {
+                'createSharedModel': {
+                    'modelName': 'SharedModel',
+                    'requestRequiredFields': ['requestField'],
+                },
+            },
+        }
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data('createSharedModel', {})
+
+        assert not valid
+        assert {'required': ['requestField']} == rez
+
+    def test_operation_request_requirements_still_validate_supplied_fields(self):
+        spec = {
+            'models': {
+                'SharedModel': {
+                    'type': 'object',
+                    'required': ['requestField', 'serverGeneratedField'],
+                    'properties': {
+                        'requestField': {'type': 'string'},
+                        'serverGeneratedField': {'type': 'object'},
+                    },
+                },
+            },
+            'operations': {
+                'createSharedModel': {
+                    'modelName': 'SharedModel',
+                    'requestRequiredFields': ['requestField'],
+                },
+            },
+        }
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data(
+            'createSharedModel',
+            {
+                'requestField': 'input',
+                'serverGeneratedField': 'not-an-object',
+            },
+        )
+
+        assert not valid
+        assert {
+            'invalid_type': [{
+                'path': 'serverGeneratedField',
+                'expected_type': 'object',
+                'actually_value': 'not-an-object',
+            }],
+        } == rez
+
     def test_simple_types(self):
         local_mock_data = {
             'models': {

--- a/tests/unit/module_utils/test_fmc_swagger_validator.py
+++ b/tests/unit/module_utils/test_fmc_swagger_validator.py
@@ -708,6 +708,191 @@ class TestFmcSwaggerValidator(unittest.TestCase):
             ]
         }) == sort_validator_rez(rez)
 
+    def test_array_with_free_form_objects(self):
+        spec = {
+            'models': {
+                'FreeFormObjectContainer': {
+                    'type': 'object',
+                    'properties': {
+                        'metadata': {
+                            'type': 'array',
+                            'items': {'type': 'object'}
+                        }
+                    }
+                }
+            },
+            'operations': {
+                'createFreeFormObjectContainer': {
+                    'modelName': 'FreeFormObjectContainer'
+                }
+            }
+        }
+        data = {
+            'metadata': [{
+                'id': 'example-id',
+                'type': 'ExampleType',
+                'name': 'Example name'
+            }]
+        }
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data('createFreeFormObjectContainer', data)
+
+        assert valid
+        assert rez is None
+
+    def test_array_with_free_form_objects_rejects_non_object(self):
+        spec = {
+            'models': {
+                'FreeFormObjectContainer': {
+                    'type': 'object',
+                    'properties': {
+                        'metadata': {
+                            'type': 'array',
+                            'items': {'type': 'object'}
+                        }
+                    }
+                }
+            },
+            'operations': {
+                'createFreeFormObjectContainer': {
+                    'modelName': 'FreeFormObjectContainer'
+                }
+            }
+        }
+        data = {'metadata': ['not-an-object']}
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data('createFreeFormObjectContainer', data)
+
+        assert not valid
+        assert {
+            'invalid_type': [{
+                'path': 'metadata[0]',
+                'expected_type': 'object',
+                'actually_value': 'not-an-object'
+            }]
+        } == rez
+
+    def test_array_with_typed_additional_properties(self):
+        spec = {
+            'models': {
+                'StringMapContainer': {
+                    'type': 'object',
+                    'properties': {
+                        'metadata': {
+                            'type': 'array',
+                            'items': {
+                                'type': 'object',
+                                'additionalProperties': {'type': 'string'}
+                            }
+                        }
+                    }
+                }
+            },
+            'operations': {
+                'createStringMapContainer': {
+                    'modelName': 'StringMapContainer'
+                }
+            }
+        }
+        data = {
+            'metadata': [{
+                'id': 'example-id',
+                'name': 'Example name'
+            }]
+        }
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data('createStringMapContainer', data)
+
+        assert valid
+        assert rez is None
+
+    def test_array_with_typed_additional_properties_rejects_invalid_value(self):
+        spec = {
+            'models': {
+                'StringMapContainer': {
+                    'type': 'object',
+                    'properties': {
+                        'metadata': {
+                            'type': 'array',
+                            'items': {
+                                'type': 'object',
+                                'additionalProperties': {'type': 'string'}
+                            }
+                        }
+                    }
+                }
+            },
+            'operations': {
+                'createStringMapContainer': {
+                    'modelName': 'StringMapContainer'
+                }
+            }
+        }
+        data = {
+            'metadata': [{
+                'id': 'example-id',
+                'retryCount': 3
+            }]
+        }
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data('createStringMapContainer', data)
+
+        assert not valid
+        assert {
+            'invalid_type': [{
+                'path': 'metadata[0].retryCount',
+                'expected_type': 'string',
+                'actually_value': 3
+            }]
+        } == rez
+
+    def test_referenced_additional_properties_validate_nested_object(self):
+        spec = {
+            'models': {
+                'ReferenceMapContainer': {
+                    'type': 'object',
+                    'properties': {
+                        'metadata': {
+                            'type': 'object',
+                            'additionalProperties': {
+                                '$ref': '#/definitions/ReferenceModel'
+                            }
+                        }
+                    }
+                },
+                'ReferenceModel': {
+                    'type': 'object',
+                    'required': ['id'],
+                    'properties': {
+                        'id': {'type': 'string'}
+                    }
+                }
+            },
+            'operations': {
+                'createReferenceMapContainer': {
+                    'modelName': 'ReferenceMapContainer'
+                }
+            }
+        }
+        data = {
+            'metadata': {
+                'first': {
+                    'id': 3
+                }
+            }
+        }
+
+        valid, rez = FmcSwaggerValidator(spec).validate_data('createReferenceMapContainer', data)
+
+        assert not valid
+        assert {
+            'invalid_type': [{
+                'path': 'metadata.first.id',
+                'expected_type': 'string',
+                'actually_value': 3
+            }]
+        } == rez
+
     def test_simple_types(self):
         local_mock_data = {
             'models': {


### PR DESCRIPTION
## Bug
  Fixes Swagger validation for API operations whose request models contain free-form objects or inaccurate required declarations.

  The generated FMC Swagger schema can mark fields as required even when the API accepts requests without them. This caused FMCAnsible to reject valid payloads before sending them to FMC.

  ## Changes
  - Derive operation-specific required fields from the Swagger request examples when available.
  - Preserve the original schema requirements as a fallback when no request example exists.
  - Continue validating field types and nested required properties.
  - Add regression tests for free-form objects, operation-specific requirements, missing required fields, and invalid field types