### PR TITLE
Prepare cisco.fmcansible 1.1.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,48 @@ Cisco FMCAnsible Collection Release Notes
 
 .. contents:: Topics
 
+v1.1.1
+======
+
+Release Summary
+---------------
+
+Maintenance release fixing long-running on-prem FMC authentication, upsert
+query-parameter handling, and Swagger request validation.
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- The minimum supported version is now ``ansible-core 2.16``. Environments
+  using older Ansible releases must upgrade Ansible before installing this
+  collection version.
+
+Minor Changes
+-------------
+
+- Removed unused ``community.general`` and ``community.network`` collection
+  dependencies. ``ansible.netcommon`` now requires version 8.5.2 or later, and
+  ``ansible.utils`` requires version 5.1.2 or later.
+- Replaced deprecated ``ansible.module_utils.six`` compatibility imports with
+  native Python 3 equivalents for current Ansible sanity compatibility.
+- Updated Python and Ansible content to pass the Galaxy importer flake8 and
+  ansible-lint checks.
+
+Bugfixes
+--------
+
+- Automatically refresh expired on-prem FMC access tokens and retry the
+  interrupted API request. If the refresh token is invalid or exhausted,
+  authenticate again using the configured FMC credentials.
+- Keep cdFMC/SCC bearer-token authentication separate from the on-prem FMC
+  username/password refresh and reauthentication workflow.
+- Preserve operation-specific query parameters when an upsert performs its
+  GETALL lookup, including parameters such as access-policy category
+  ``section``.
+- Correct Swagger validation for free-form objects while continuing to validate
+  explicitly defined fields and fields required by request examples.
+
+
 v1.1.0
 ======
 
@@ -143,4 +185,3 @@ Release Summary
 ---------------
 
 This is the first release of the ``cisco.fmcansible`` collection.
-

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,5 +1,35 @@
 ancestor: null
 releases:
+  1.1.1:
+    changes:
+      release_summary: 'Maintenance release fixing long-running on-prem FMC authentication,
+        upsert query-parameter handling, and Swagger request validation.
+
+        '
+      breaking_changes:
+        - The minimum supported version is now ``ansible-core 2.16``. Environments
+          using older Ansible releases must upgrade Ansible before installing this
+          collection version.
+      minor_changes:
+        - Removed unused ``community.general`` and ``community.network`` collection
+          dependencies. ``ansible.netcommon`` now requires version 8.5.2 or later,
+          and ``ansible.utils`` requires version 5.1.2 or later.
+        - Replaced deprecated ``ansible.module_utils.six`` compatibility imports
+          with native Python 3 equivalents for current Ansible sanity compatibility.
+        - Updated Python and Ansible content to pass the Galaxy importer flake8
+          and ansible-lint checks.
+      bugfixes:
+        - Automatically refresh expired on-prem FMC access tokens and retry the
+          interrupted API request. If the refresh token is invalid or exhausted,
+          authenticate again using the configured FMC credentials.
+        - Keep cdFMC/SCC bearer-token authentication separate from the on-prem FMC
+          username/password refresh and reauthentication workflow.
+        - Preserve operation-specific query parameters when an upsert performs its
+          GETALL lookup, including parameters such as access-policy category
+          ``section``.
+        - Correct Swagger validation for free-form objects while continuing to
+          validate explicitly defined fields and fields required by request examples.
+    release_date: '2026-08-12'
   1.1.0:
     changes:
       release_summary: 'First stable release of the 1.x line, promoting the v1.0.10

--- a/docs/examples/ftd-ha-upgrade/ftd-ha-upgrade.yml
+++ b/docs/examples/ftd-ha-upgrade/ftd-ha-upgrade.yml
@@ -3,21 +3,18 @@
   hosts: fmc
 
   connection: httpapi
-  collections:
-    - cisco.fmcansible
-
   vars_files:
     - vars.yml
 
   roles:
     # Step 1: Get FMC domains
-    - role: get_domains
+    - role: cisco.fmcansible.get_domains
       register_as: fmc_domains
       save_to_file: true
       output_dir: "{{ output_directory | default('.') }}"
 
     # Step 2: Get upgrade packages and filter by version
-    - role: get_upgrade_packages
+    - role: cisco.fmcansible.get_upgrade_packages
       register_as: upgrade_packages
       version_filter: "{{ version }}"
       filter_by_version: true
@@ -25,7 +22,7 @@
       output_dir: "{{ output_directory | default('.') }}"
 
     # Step 3: Get HA devices and build target lists
-    - role: get_ha_devices
+    - role: cisco.fmcansible.get_ha_devices
       domain_uuid: "{{ fmc_domains[0].uuid }}"
       register_as: ha_devices
       filter_by_names: true
@@ -35,7 +32,7 @@
       output_dir: "{{ output_directory | default('.') }}"
 
     # Step 4: Create backup of HA devices
-    - role: device_backup
+    - role: cisco.fmcansible.device_backup
       domain_uuid: "{{ fmc_domains[0].uuid }}"
       target_devices: "{{ ha_devices_target_containers }}"
       register_as: device_backup
@@ -48,7 +45,7 @@
       output_dir: "{{ output_directory | default('.') }}"
 
     # Step 5: Perform readiness check
-    - role: device_upgrade
+    - role: cisco.fmcansible.device_upgrade
       domain_uuid: "{{ fmc_domains[0].uuid }}"
       upgrade_package: "{{ upgrade_packages_filtered }}"
       target_devices: "{{ ha_devices_target_devices }}"
@@ -63,7 +60,7 @@
       output_dir: "{{ output_directory | default('.') }}"
 
     # Step 6: Perform actual upgrade
-    - role: device_upgrade
+    - role: cisco.fmcansible.device_upgrade
       domain_uuid: "{{ fmc_domains[0].uuid }}"
       upgrade_package: "{{ upgrade_packages_filtered }}"
       target_devices: "{{ ha_devices_target_devices }}"
@@ -80,7 +77,7 @@
 
   post_tasks:
     - name: Display upgrade summary
-      debug:
+      ansible.builtin.debug:
         msg:
           - "=== FTD HA Upgrade Summary ==="
           - "Domain: {{ fmc_domains[0].name }}"

--- a/docs/examples/get-access-policies/get_access_policies.yaml
+++ b/docs/examples/get-access-policies/get_access_policies.yaml
@@ -3,10 +3,8 @@
   hosts: vfmc
 
   connection: httpapi
-  collections:
-    - cisco.fmcansible
   vars_files:
     - vars.yml
 
   roles:
-    - role: get_access_policies
+    - role: cisco.fmcansible.get_access_policies

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,3 +1,4 @@
+---
 namespace: cisco
 name: fmcansible
 version: 1.1.1
@@ -31,4 +32,26 @@ repository: https://github.com/CiscoDevNet/FMCAnsible
 homepage: https://github.com/CiscoDevNet/FMCAnsible
 issues: https://github.com/CiscoDevNet/FMCAnsible/issues
 
-build_ignore: []
+build_ignore:
+  # Repository and CI configuration
+  - .github
+  - .gitignore
+  - ansible.cfg
+
+  # Development and test tooling
+  - tests
+  - scripts
+  - test-requirements.txt
+  - Dockerfile
+  - Dockerfile_integration
+  - changelogs
+
+  # Local and generated artifacts
+  - "**/.DS_Store"
+  - "**/__pycache__"
+  - "**/.pytest_cache"
+  - "**/tests/output"
+  - .coverage
+  - coverage.xml
+  - "*.log"
+  - "*.tar.gz"

--- a/plugins/httpapi/client.py
+++ b/plugins/httpapi/client.py
@@ -151,8 +151,9 @@ class InternalHttpClient(object):
 
         error_message = self._get_error_message(response_body, res.status)
         if self._is_error_response(response_body, res.status):
-            if (int(res.status) in AUTH_ERROR_STATUS_CODES or
-                    'Invalid refresh token' in error_message):
+            auth_error = int(res.status) in AUTH_ERROR_STATUS_CODES
+            invalid_refresh = 'Invalid refresh token' in error_message
+            if auth_error or invalid_refresh:
                 return self._send_stored_login()
             raise InternalHttpClientError(error_message, res.status)
 
@@ -214,11 +215,10 @@ class InternalHttpClient(object):
         msg = self._get_error_message(response, status_code)
         status_code = int(status_code)
 
-        is_auth_error = (
-            status_code in AUTH_ERROR_STATUS_CODES or
-            'Access token invalid' in msg or
-            'Invalid refresh token' in msg
-        )
+        is_auth_status = status_code in AUTH_ERROR_STATUS_CODES
+        access_token_invalid = 'Access token invalid' in msg
+        refresh_token_invalid = 'Invalid refresh token' in msg
+        is_auth_error = is_auth_status or access_token_invalid or refresh_token_invalid
         if is_auth_error:
             if not self._enable_auth_recovery:
                 raise InternalHttpClientError(msg, status_code)
@@ -262,18 +262,17 @@ class InternalHttpClient(object):
         if isinstance(response, dict):
             err = response.get('error')
             if isinstance(err, dict):
-                msg = (
-                    err.get('data') or
-                    err.get('message') or
-                    iter_messages(err.get('messages'))
-                )
+                msg = err.get('data')
+                if not msg:
+                    msg = err.get('message')
+                if not msg:
+                    msg = iter_messages(err.get('messages'))
                 if msg:
                     return str(msg)
             elif err:
-                description = (
-                    response.get('errorDescription') or
-                    response.get('error_description')
-                )
+                description = response.get('errorDescription')
+                if not description:
+                    description = response.get('error_description')
                 if description:
                     return '{0}: {1}'.format(err, description)
                 return str(err)

--- a/plugins/module_utils/cache.py
+++ b/plugins/module_utils/cache.py
@@ -76,8 +76,9 @@ class ResponseCache:
             existing_response = self._cache[host][name]
 
             # If both are dictionaries, check if they are the same
-            if (isinstance(existing_response, dict) and
-                    isinstance(response_body, dict)):
+            existing_is_dict = isinstance(existing_response, dict)
+            response_is_dict = isinstance(response_body, dict)
+            if existing_is_dict and response_is_dict:
 
                 # If dictionaries are different, combine them into a list
                 if existing_response != response_body:

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -29,7 +29,6 @@ except ImportError:
 
 import re
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.collections import is_string
 
 INVALID_IDENTIFIER_SYMBOLS = r'[^a-zA-Z0-9_]'

--- a/plugins/module_utils/configuration.py
+++ b/plugins/module_utils/configuration.py
@@ -25,7 +25,6 @@ __metaclass__ = type
 import copy
 from functools import partial
 
-from ansible.module_utils.six import iteritems
 from ansible_collections.cisco.fmcansible.plugins.module_utils.common import (
     FmcConfigurationError, FmcServerError, FmcUnexpectedResponse, HTTPMethod,
     ResponseParams, add_missing_properties_left_to_right,
@@ -228,8 +227,8 @@ class OperationChecker(object):
         :return: True if all criteria required to provide requested called operation are satisfied, otherwise False
         :rtype: bool
         """
-        has_edit_op = next((name for name, spec in iteritems(operations) if cls.is_edit_operation(name, spec)), None)
-        has_get_list_op = next((name for name, spec in iteritems(operations)
+        has_edit_op = next((name for name, spec in operations.items() if cls.is_edit_operation(name, spec)), None)
+        has_get_list_op = next((name for name, spec in operations.items()
                                 if cls.is_get_list_operation(name, spec)), None)
         return has_edit_op and has_get_list_op
 
@@ -299,7 +298,7 @@ class BaseConfigurationResource(object):
         if model_name not in self._models_operations_specs_cache:
             model_op_specs = self._conn.get_operation_specs_by_model_name(model_name)
             self._models_operations_specs_cache[model_name] = model_op_specs
-            for op_name, op_spec in iteritems(model_op_specs):
+            for op_name, op_spec in model_op_specs.items():
                 self._operation_spec_cache.setdefault(op_name, op_spec)
         return self._models_operations_specs_cache[model_name]
 
@@ -309,7 +308,7 @@ class BaseConfigurationResource(object):
         """
         # filter func that filters by params, usually name
         def match_filters(obj):
-            for k, v in iteritems(filter_params):
+            for k, v in filter_params.items():
                 if k not in obj or obj[k] != v:
                     return False
             return True
@@ -347,7 +346,7 @@ class BaseConfigurationResource(object):
 
         operation_request = dict(params)
         operation_request[ParamName.QUERY_PARAMS] = {
-            name: value for name, value in iteritems(query_params)
+            name: value for name, value in query_params.items()
             if name in supported_query_params
         }
         return operation_request
@@ -627,7 +626,7 @@ class BaseConfigurationResource(object):
 
     @staticmethod
     def _get_operation_name(checker, operations):
-        return next((op_name for op_name, op_spec in iteritems(operations) if checker(op_name, op_spec)), None)
+        return next((op_name for op_name, op_spec in operations.items() if checker(op_name, op_spec)), None)
 
     def _add_upserted_object(self, model_operations, params):
         add_op_name = self._get_operation_name(self._operation_checker.is_add_operation, model_operations)
@@ -651,9 +650,12 @@ class BaseConfigurationResource(object):
         Determines if the edit operation begins with 'edit' or 'update', and contains
         the identity param (i.e. objectId) in its url path
         """
-        return self._operation_checker.is_edit_operation(operation_name, operation_spec) and \
-            (operation_spec.get(OperationField.PARAMETERS) is None or
-             operation_spec[OperationField.PARAMETERS]['path'].get(PATH_IDENTITY_PARAM) is not None)
+        is_edit = self._operation_checker.is_edit_operation(operation_name, operation_spec)
+        parameters = operation_spec.get(OperationField.PARAMETERS)
+        has_identity_param = parameters is None
+        if parameters is not None:
+            has_identity_param = parameters['path'].get(PATH_IDENTITY_PARAM) is not None
+        return is_edit and has_identity_param
 
     def upsert_object(self, op_name, params):
         """

--- a/plugins/module_utils/facts.py
+++ b/plugins/module_utils/facts.py
@@ -143,7 +143,7 @@ class FmcFactsBase(object):
             else:
                 # Return empty list if unexpected format
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -159,7 +159,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -175,7 +175,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -191,7 +191,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -207,7 +207,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -228,7 +228,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -244,7 +244,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -260,7 +260,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -276,7 +276,7 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []
 
@@ -292,6 +292,6 @@ class FmcFactsBase(object):
                 return result['items']
             else:
                 return []
-        except Exception as e:
+        except Exception:
             # Return empty list if operation fails
             return []

--- a/plugins/module_utils/fmc_swagger_client.py
+++ b/plugins/module_utils/fmc_swagger_client.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible_collections.cisco.fmcansible.plugins.module_utils.common import HTTPMethod
-from ansible.module_utils.six import integer_types, string_types, iteritems
 
 FILE_MODEL_NAME = '_File'
 SUCCESS_RESPONSE_CODE = '200'
@@ -201,7 +200,7 @@ class FmcSwaggerParser:
 
     def _get_model_operations(self, operations):
         model_operations = {}
-        for operations_name, params in iteritems(operations):
+        for operations_name, params in operations.items():
             model_name = params[OperationField.MODEL_NAME]
             # FMC uses separate model names for list operations, so strip out "ListContainer" and merge into main model ops object
             model_name = self._resolve_model_name(model_name)
@@ -211,8 +210,8 @@ class FmcSwaggerParser:
     def _get_operations(self, spec):
         paths_dict = spec[PropName.PATHS]
         operations_dict = {}
-        for url, operation_params in iteritems(paths_dict):
-            for method, params in iteritems(operation_params):
+        for url, operation_params in paths_dict.items():
+            for method, params in operation_params.items():
                 operation = {
                     OperationField.METHOD: method,
                     OperationField.URL: self._base_path + url,
@@ -261,7 +260,7 @@ class FmcSwaggerParser:
                 continue
 
             for title, example in examples.items():
-                if not isinstance(title, string_types) or not title.lower().startswith(REQUEST_EXAMPLE_PREFIX):
+                if not isinstance(title, str) or not title.lower().startswith(REQUEST_EXAMPLE_PREFIX):
                     continue
                 if isinstance(example, dict):
                     request_examples.append(example)
@@ -503,7 +502,7 @@ class FmcSwaggerValidator:
         return True, None
 
     def _check_validate_data_params(self, data, operation_name):
-        if not operation_name or not isinstance(operation_name, string_types):
+        if not operation_name or not isinstance(operation_name, str):
             raise IllegalArgumentException("The operation_name parameter must be a non-empty string")
         if not isinstance(data, dict) and not isinstance(data, list):
             raise IllegalArgumentException("The data parameter must be a dict or list")
@@ -606,7 +605,7 @@ class FmcSwaggerValidator:
             return True, None
 
     def _check_validate_url_params(self, operation, params):
-        if not operation or not isinstance(operation, string_types):
+        if not operation or not isinstance(operation, str):
             raise IllegalArgumentException("The operation_name parameter must be a non-empty string")
         if not isinstance(params, dict):
             raise IllegalArgumentException("The params parameter must be a dict")
@@ -771,16 +770,16 @@ class FmcSwaggerValidator:
         if value is None and allow_null:
             return True
         elif expected_type == PropType.STRING:
-            return isinstance(value, string_types)
+            return isinstance(value, str)
         elif expected_type == PropType.BOOLEAN:
             return isinstance(value, bool)
         elif expected_type == PropType.INTEGER:
-            is_integer = isinstance(value, integer_types) and not isinstance(value, bool)
-            is_digit_string = isinstance(value, string_types) and value.isdigit()
+            is_integer = isinstance(value, int) and not isinstance(value, bool)
+            is_digit_string = isinstance(value, str) and value.isdigit()
             return is_integer or is_digit_string
         elif expected_type == PropType.NUMBER:
-            is_number = isinstance(value, (integer_types, float)) and not isinstance(value, bool)
-            is_numeric_string = isinstance(value, string_types) and is_numeric_string(value)
+            is_number = isinstance(value, (int, float)) and not isinstance(value, bool)
+            is_numeric_string = isinstance(value, str) and is_numeric_string(value)
             return is_number or is_numeric_string
         return False
 

--- a/roles/device_backup/tasks/main.yml
+++ b/roles/device_backup/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Main tasks file for device_backup role
 - name: Validate required variables
-  assert:
+  ansible.builtin.assert:
     that:
       - domain_uuid is defined
       - domain_uuid | length > 0
@@ -22,19 +22,20 @@
   register: backup_result
 
 - name: Set backup task fact
-  set_fact:
+  ansible.builtin.set_fact:
     "{{ register_as }}_task_id": "{{ ansible_facts[register_as].metadata.task.id }}"
 
 - name: Save backup task info to JSON file
-  copy:
+  ansible.builtin.copy:
     content: "{{ ansible_facts[register_as] | to_nice_json }}"
     dest: "{{ output_dir }}/backup_task.json"
+    mode: "0600"
   delegate_to: localhost
   when: save_to_file | bool
 
 - name: Display backup task information
-  debug:
-    msg: 
+  ansible.builtin.debug:
+    msg:
       - "Backup task initiated successfully"
       - "Task ID: {{ ansible_facts[register_as].metadata.task.id }}"
       - "Devices to backup: {{ target_devices | length }}"
@@ -53,26 +54,26 @@
   when: wait_for_completion | bool
 
 - name: Set backup status fact
-  set_fact:
+  ansible.builtin.set_fact:
     "{{ register_as }}_status": "{{ backup_status.response }}"
-  when: 
+  when:
     - wait_for_completion | bool
     - backup_status is defined
 
 - name: Verify backup success
-  assert:
+  ansible.builtin.assert:
     that: backup_status.response.status == "COMPLETED"
     fail_msg: "Backup failed: {{ backup_status.response.error | default('Unknown error') }}"
     success_msg: "Backup completed successfully for {{ target_devices | length }} device(s)!"
-  when: 
+  when:
     - wait_for_completion | bool
     - verify_success | bool
 
 - name: Display backup completion status
-  debug:
+  ansible.builtin.debug:
     msg:
       - "Backup Status: {{ backup_status.response.status }}"
       - "Message: {{ backup_status.response.message | default('No message') }}"
-  when: 
+  when:
     - wait_for_completion | bool
     - backup_status is defined

--- a/roles/device_upgrade/tasks/main.yml
+++ b/roles/device_upgrade/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Main tasks file for device_upgrade role
 - name: Validate required variables
-  assert:
+  ansible.builtin.assert:
     that:
       - domain_uuid is defined
       - domain_uuid | length > 0
@@ -12,9 +12,10 @@
     fail_msg: "domain_uuid, upgrade_package, and target_devices are required variables"
 
 - name: Display upgrade information
-  debug:
+  ansible.builtin.debug:
     msg:
-      - "Starting {% if readiness_check_only %}readiness check{% else %}upgrade{% endif %} for package '{{ upgrade_package.name | default(upgrade_package.id) }}' on {{ target_devices | length }} device(s)"
+      - "Starting {% if readiness_check_only %}readiness check{% else %}upgrade{% endif %} for package '{{ upgrade_package.name | default(upgrade_package.id) }}'
+        on {{ target_devices | length }} device(s)"
       - "Readiness check only: {{ readiness_check_only }}"
       - "Enable upgrade revert: {{ enable_upgrade_revert }}"
       - "Auto upgrade cancel: {{ auto_upgrade_cancel }}"
@@ -36,19 +37,20 @@
   register: upgrade_result
 
 - name: Set upgrade task fact
-  set_fact:
+  ansible.builtin.set_fact:
     "{{ register_as }}_task_id": "{{ ansible_facts[register_as].metadata.task.id }}"
 
 - name: Save upgrade task info to JSON file
-  copy:
+  ansible.builtin.copy:
     content: "{{ ansible_facts[register_as] | to_nice_json }}"
     dest: "{{ output_dir }}/{% if readiness_check_only %}readiness_check{% else %}upgrade{% endif %}_task.json"
+    mode: "0600"
   delegate_to: localhost
   when: save_to_file | bool
 
 - name: Display upgrade task information
-  debug:
-    msg: 
+  ansible.builtin.debug:
+    msg:
       - "{% if readiness_check_only %}Readiness check{% else %}Upgrade{% endif %} task initiated successfully"
       - "Task ID: {{ ansible_facts[register_as].metadata.task.id }}"
       - "Devices: {{ target_devices | length }}"
@@ -68,27 +70,28 @@
   when: wait_for_completion | bool
 
 - name: Set upgrade status fact
-  set_fact:
+  ansible.builtin.set_fact:
     "{{ register_as }}_status": "{{ upgrade_status.response }}"
-  when: 
+  when:
     - wait_for_completion | bool
     - upgrade_status is defined
 
 - name: Verify upgrade/readiness check success
-  assert:
+  ansible.builtin.assert:
     that: upgrade_status.response.status == "COMPLETED"
-    fail_msg: "{% if readiness_check_only %}Readiness check{% else %}Upgrade{% endif %} failed: {{ upgrade_status.response.error | default(upgrade_status.response.message | default('Unknown error')) }}"
+    fail_msg: "{% if readiness_check_only %}Readiness check{% else %}Upgrade{% endif %} failed: {{ upgrade_status.response.error | default(upgrade_status.response.message
+      | default('Unknown error')) }}"
     success_msg: "{% if readiness_check_only %}Readiness check{% else %}Upgrade{% endif %} completed successfully for {{ target_devices | length }} device(s)!"
-  when: 
+  when:
     - wait_for_completion | bool
     - verify_success | bool
 
 - name: Display task completion status
-  debug:
+  ansible.builtin.debug:
     msg:
       - "{% if readiness_check_only %}Readiness Check{% else %}Upgrade{% endif %} Status: {{ upgrade_status.response.status }}"
       - "Message: {{ upgrade_status.response.message | default('No message') }}"
       - "{% if upgrade_status.response.error is defined %}Error: {{ upgrade_status.response.error }}{% endif %}"
-  when: 
+  when:
     - wait_for_completion | bool
     - upgrade_status is defined

--- a/roles/get_access_policies/tasks/main.yml
+++ b/roles/get_access_policies/tasks/main.yml
@@ -8,7 +8,7 @@
   register: access_policies
 
 - name: Process each access policy
-  include_tasks: process_policy.yml
+  ansible.builtin.include_tasks: process_policy.yml
   loop: "{{ access_policies.response['items'] }}"
   loop_control:
     loop_var: policy

--- a/roles/get_access_policies/tasks/process_policy.yml
+++ b/roles/get_access_policies/tasks/process_policy.yml
@@ -11,21 +11,22 @@
   register: policy_rules
 
 - name: Initialize policy output
-  set_fact:
+  ansible.builtin.set_fact:
     policy_output:
       name: "{{ policy.name }}"
       id: "{{ policy.id }}"
       rules: []
 
 - name: Process each rule to get nested objects
-  include_tasks: process_rule.yml
+  ansible.builtin.include_tasks: process_rule.yml
   loop: "{{ policy_rules.response['items'] | default([]) }}"
   loop_control:
     loop_var: rule
   when: policy_rules.response is defined and policy_rules.response['items'] is defined and policy_rules.response['items'] | length > 0
 
 - name: Save policy output to JSON file
-  copy:
+  ansible.builtin.copy:
     content: "{{ policy_output | to_nice_json }}"
     dest: "{{ output_dir }}/{{ policy.name | replace('/', '_') }}_access_policy.json"
+    mode: "0600"
   delegate_to: localhost

--- a/roles/get_access_policies/tasks/process_rule.yml
+++ b/roles/get_access_policies/tasks/process_rule.yml
@@ -43,14 +43,8 @@
   when: collect_ports | default(true)
 
 - name: Add rule with objects to policy output
-  set_fact:
-    policy_output: "{{ policy_output | combine({'rules': policy_output.rules + [{
-      'name': rule.name,
-      'id': rule.id,
-      'sourceNetworks': source_networks.response | default({}),
-      'destinationNetworks': dest_networks.response | default({}),
-      'sourcePorts': source_ports.response | default({}) if collect_ports | default(true) else {},
-      'destinationPorts': dest_ports.response | default({}) if collect_ports | default(true) else {},
-      'action': rule.action | default(''),
-      'enabled': rule.enabled | default(true)
-    }]}) }}"
+  ansible.builtin.set_fact:
+    policy_output: "{{ policy_output | combine({'rules': policy_output.rules + [{'name': rule.name, 'id': rule.id, 'sourceNetworks': source_networks.response | default({}),
+      'destinationNetworks': dest_networks.response | default({}), 'sourcePorts': source_ports.response | default({}) if collect_ports | default(true) else {}, 'destinationPorts':
+      dest_ports.response | default({}) if collect_ports | default(true) else {}, 'action': rule.action | default(''), 'enabled': rule.enabled | default(true)}]})
+      }}"

--- a/roles/get_domains/tasks/main.yml
+++ b/roles/get_domains/tasks/main.yml
@@ -6,12 +6,13 @@
     register_as: "{{ register_as }}"
 
 - name: Save domains to JSON file
-  copy:
+  ansible.builtin.copy:
     content: "{{ ansible_facts[register_as] | to_nice_json }}"
     dest: "{{ output_dir }}/fmc_domains.json"
+    mode: "0600"
   delegate_to: localhost
   when: save_to_file | bool
 
 - name: Display found domains
-  debug:
+  ansible.builtin.debug:
     msg: "Found {{ ansible_facts[register_as] | length }} domain(s): {{ ansible_facts[register_as] | map(attribute='name') | list | join(', ') }}"

--- a/roles/get_ha_devices/meta/main.yml
+++ b/roles/get_ha_devices/meta/main.yml
@@ -22,6 +22,6 @@ galaxy_info:
     - security
     - networking
     - ha
-    - high-availability
+    - highavailability
 
 dependencies: []

--- a/roles/get_ha_devices/tasks/main.yml
+++ b/roles/get_ha_devices/tasks/main.yml
@@ -10,63 +10,64 @@
     register_as: "{{ register_as }}"
 
 - name: Save HA devices to JSON file
-  copy:
+  ansible.builtin.copy:
     content: "{{ ansible_facts[register_as] | to_nice_json }}"
     dest: "{{ output_dir }}/ha_devices.json"
+    mode: "0600"
   delegate_to: localhost
   when: save_to_file | bool
 
 - name: Display found HA devices
-  debug:
+  ansible.builtin.debug:
     msg: "Found {{ ansible_facts[register_as] | length }} HA device pair(s): {{ ansible_facts[register_as] | map(attribute='name') | list | join(', ') }}"
 
 - name: Filter HA devices by names
-  set_fact:
+  ansible.builtin.set_fact:
     filtered_ha_devices: >-
-      {{ ansible_facts[register_as] 
+      {{ ansible_facts[register_as]
         | selectattr('name','in', ha_pair_names)
         | list }}
-  when: 
-    - ha_pair_names is defined 
+  when:
+    - ha_pair_names is defined
     - ha_pair_names | length > 0
     - filter_by_names | bool
 
 - name: Set filtered HA devices fact
-  set_fact:
+  ansible.builtin.set_fact:
     "{{ register_as }}_filtered": "{{ filtered_ha_devices }}"
   when: filtered_ha_devices is defined
 
 - name: Display filtered HA devices
-  debug:
+  ansible.builtin.debug:
     msg: "Selected HA device pairs: {{ filtered_ha_devices | map(attribute='name') | list | join(', ') }}"
   when: filtered_ha_devices is defined
 
 - name: Build target containers list
-  set_fact:
+  ansible.builtin.set_fact:
     ha_target_containers: >-
       [{% for device in filtered_ha_devices %}
         { "id": "{{ device.id }}",
           "type": "HAContainer",
           "name": "{{ device.name }}" }{{ "," if not loop.last else "" }}{% endfor %}]
-  when: 
+  when:
     - filtered_ha_devices is defined
     - build_target_lists | bool
 
 - name: Build target devices list (primary devices)
-  set_fact:
+  ansible.builtin.set_fact:
     ha_target_devices: >-
       [{% for device in filtered_ha_devices %}
         { "id": "{{ device.primary.id }}",
           "type": "Device",
           "name": "{{ device.primary.name }}" }{{ "," if not loop.last else "" }}{% endfor %}]
-  when: 
+  when:
     - filtered_ha_devices is defined
     - build_target_lists | bool
 
 - name: Set target lists facts
-  set_fact:
+  ansible.builtin.set_fact:
     "{{ register_as }}_target_containers": "{{ ha_target_containers | from_yaml }}"
     "{{ register_as }}_target_devices": "{{ ha_target_devices | from_yaml }}"
-  when: 
+  when:
     - ha_target_containers is defined
     - ha_target_devices is defined

--- a/roles/get_upgrade_packages/tasks/main.yml
+++ b/roles/get_upgrade_packages/tasks/main.yml
@@ -6,37 +6,38 @@
     register_as: "{{ register_as }}"
 
 - name: Save upgrade packages to JSON file
-  copy:
+  ansible.builtin.copy:
     content: "{{ ansible_facts[register_as] | to_nice_json }}"
     dest: "{{ output_dir }}/upgrade_packages.json"
+    mode: "0600"
   delegate_to: localhost
   when: save_to_file | bool
 
 - name: Display found upgrade packages
-  debug:
+  ansible.builtin.debug:
     msg: "Found {{ ansible_facts[register_as] | length }} upgrade package(s): {{ ansible_facts[register_as] | map(attribute='name') | list | join(', ') }}"
 
 - name: Find package by version filter
-  set_fact:
+  ansible.builtin.set_fact:
     filtered_package: >-
-      {{ ansible_facts[register_as] 
+      {{ ansible_facts[register_as]
         | selectattr('name','contains', version_filter)
         | list | first }}
-  when: 
-    - version_filter is defined 
+  when:
+    - version_filter is defined
     - version_filter | length > 0
     - filter_by_version | bool
-  failed_when: 
+  failed_when:
     - version_filter is defined
     - filter_by_version | bool
     - (ansible_facts[register_as] | selectattr('name','contains', version_filter) | list | length == 0)
 
 - name: Set filtered package fact
-  set_fact:
+  ansible.builtin.set_fact:
     "{{ register_as }}_filtered": "{{ filtered_package }}"
   when: filtered_package is defined
 
 - name: Display filtered package
-  debug:
+  ansible.builtin.debug:
     msg: "Selected upgrade package: {{ filtered_package.name }} (ID: {{ filtered_package.id }})"
   when: filtered_package is defined

--- a/samples/fmc_configuration/access_policy_create.yml
+++ b/samples/fmc_configuration/access_policy_create.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create an access policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -8,7 +10,7 @@
         operation: "createAccessPolicy"
         data:
           type: "AccessPolicy"
-          name: "{{accesspolicy_name | default('AccessPolicy1') }}"
+          name: "{{ accesspolicy_name | default('AccessPolicy1') }}"
           defaultAction: { "action": "TRUST" }
         path_params:
           domainUUID: "{{ ansible_facts.fmc.domains[0].uuid }}"

--- a/samples/fmc_configuration/access_policy_delete.yml
+++ b/samples/fmc_configuration/access_policy_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete an access policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/access_rule_delete.yml
+++ b/samples/fmc_configuration/access_rule_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete an access rule
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/access_rule_with_logging_create.yml
+++ b/samples/fmc_configuration/access_rule_with_logging_create.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create an access rule with logging
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -30,9 +32,9 @@
         data:
           name: "{{ accessrule_name | default('Log traffic with malware files 2') }}"
           action: ALLOW
-          logEnd: True
-          logBegin: False
-          sendEventsToFMC: True
+          logEnd: true
+          logBegin: false
+          sendEventsToFMC: true
           filePolicy: "{{ file_policies[0] }}"
           type: AccessRule
         path_params:

--- a/samples/fmc_configuration/access_rule_with_networks_create.yml
+++ b/samples/fmc_configuration/access_rule_with_networks_create.yml
@@ -1,9 +1,11 @@
-- hosts: all
+---
+- name: Create an access rule with network objects
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
   tasks:
-    - name: create auxilary network object
+    - name: Create auxilary network object
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
@@ -32,7 +34,7 @@
           sourceNetworks:
             objects:
               - id: "{{ net1.id }}"
-                name: "{{net1.name }}"
+                name: "{{ net1.name }}"
                 type: "{{ net1.type }}"
           action: ALLOW
         path_params:
@@ -48,12 +50,12 @@
           sourceNetworks:
             objects:
               - id: "{{ net1.id }}"
-                name: "{{net1.name }}"
+                name: "{{ net1.name }}"
                 type: "{{ net1.type }}"
           destinationNetworks:
             objects:
               - id: "{{ net1.id }}"
-                name: "{{net1.name }}"
+                name: "{{ net1.name }}"
                 type: "{{ net1.type }}"
           action: BLOCK
         path_params:

--- a/samples/fmc_configuration/deployment.yml
+++ b/samples/fmc_configuration/deployment.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Deploy pending configuration
+  hosts: all
   connection: httpapi
   tasks:
     - name: Get Deployable Devices
@@ -11,7 +13,7 @@
         register_as: devices
 
     - name: Complete playbook when nothing to deploy
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: devices[0].device is undefined
 
     - name: Fetch pending changes
@@ -29,7 +31,7 @@
           version: "{{ devices[0].version }}"
           deviceList:
             - "{{ devices[0].device.id }}"
-          forceDeploy: True
+          forceDeploy: true
         path_params:
           domainUUID: "{{ ansible_facts.fmc.domains[0].uuid }}"
         register_as: deployment_job
@@ -46,6 +48,6 @@
       delay: 3
 
     - name: Stop the playbook if the deployment failed
-      fail:
+      ansible.builtin.fail:
         msg: "Deployment failed. Status: {{ deployment_status[0].status }}"
       when: deployment_status[0].status is not match("SUCCEEDED")

--- a/samples/fmc_configuration/device_registration.yml
+++ b/samples/fmc_configuration/device_registration.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Register a device
+  hosts: all
   any_errors_fatal: true
   connection: httpapi
   vars_files:
@@ -13,7 +15,7 @@
         #   name: NGFW-Access-Policy27
         register_as: accesspolicy
 
-    - name: device onboarding
+    - name: Device onboarding
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleDevice
         data:

--- a/samples/fmc_configuration/dnsservergroup_create.yml
+++ b/samples/fmc_configuration/dnsservergroup_create.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create a DNS server group
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/dnsservergroup_delete.yml
+++ b/samples/fmc_configuration/dnsservergroup_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a DNS server group
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/nat_create.yml
+++ b/samples/fmc_configuration/nat_create.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create a NAT policy and rule
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -37,9 +39,9 @@
           destinationInterface: "{{ zones[1] }}"
           sourceInterface: "{{ zones[0] }}"
           originalSource: "{{ network_results[0] }}"
-          interfaceInTranslatedSource: True
-          dns: False
-          enabled: True
+          interfaceInTranslatedSource: true
+          dns: false
+          enabled: true
           type: ftdmanualnatrule
         path_params:
           containerUUID: "{{ NAT.id }}"

--- a/samples/fmc_configuration/natpolicy_delete.yml
+++ b/samples/fmc_configuration/natpolicy_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a NAT policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/natrule_delete.yml
+++ b/samples/fmc_configuration/natrule_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a NAT rule
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -29,8 +31,8 @@
         #   name: "{{ delete_natrule_name }}"
         register_as: natrule
 
-    - name: debug
-      debug:
+    - name: Debug
+      ansible.builtin.debug:
         var: natrule
 
     - name: Delete an inside-outsite NAT rule

--- a/samples/fmc_configuration/network_object.yml
+++ b/samples/fmc_configuration/network_object.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create network objects
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/physical_interface.yml
+++ b/samples/fmc_configuration/physical_interface.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Configure a physical interface
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -28,7 +30,7 @@
               address: "{{ outside_ip | default('192.168.10.4') }}"
               netmask: "{{ outside_netmask | default('255.255.255.0') }}"
           MTU: 1500
-          enabled: True
+          enabled: true
           mode: NONE
           type: physicalinterface
           name: GigabitEthernet0/0
@@ -47,7 +49,7 @@
               address: "{{ inside_ip | default('192.168.20.2') }}"
               netmask: "{{ inside_netmask | default('255.255.255.0') }}"
           MTU: 1500
-          enabled: True
+          enabled: true
           mode: NONE
           type: physicalinterface
           name: GigabitEthernet0/1
@@ -63,10 +65,10 @@
           ifname: inside
           ipv4:
             dhcp:
-              enableDefaultRouteDHCP: True
+              enableDefaultRouteDHCP: true
               dhcpRouteMetric: 100
           MTU: 1500
-          enabled: True
+          enabled: true
           mode: NONE
           type: physicalinterface
           name: GigabitEthernet0/1

--- a/samples/fmc_configuration/port_object.yml
+++ b/samples/fmc_configuration/port_object.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create a port object
+  hosts: all
   connection: httpapi
   tasks:
     - name: Create a TCP port for PostgreSQL

--- a/samples/fmc_configuration/prefilter_policy_create.yml
+++ b/samples/fmc_configuration/prefilter_policy_create.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create a prefilter policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/prefilter_policy_delete.yml
+++ b/samples/fmc_configuration/prefilter_policy_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a prefilter policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/prefilter_rule_create.yml
+++ b/samples/fmc_configuration/prefilter_rule_create.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create a prefilter rule
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -23,7 +25,7 @@
           domainUUID: "{{ ansible_facts.fmc.domains[0].uuid }}"
           containerUUID: "{{ prefilter[1].id }}"
 
-    - name: update Prefilter Rule
+    - name: Update Prefilter Rule
       cisco.fmcansible.fmc_configuration:
         operation: updatePrefilterRule
         data:

--- a/samples/fmc_configuration/prefilter_rule_delete.yml
+++ b/samples/fmc_configuration/prefilter_rule_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a prefilter rule
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -22,7 +24,7 @@
           name: "{{ delete_prefilterrule_name | default('NGFW-Prefilter-Policy10') }}"
         register_as: prefrule
 
-    - name: delete Prefilter Rule
+    - name: Delete Prefilter Rule
       cisco.fmcansible.fmc_configuration:
         operation: deletePrefilterRule
         path_params:

--- a/samples/fmc_configuration/samples/access_policy.yml
+++ b/samples/fmc_configuration/samples/access_policy.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create an access policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -13,7 +15,7 @@
         operation: "createAccessPolicy"
         data:
           type: "AccessPolicy"
-          name: "{{accesspolicy_name | default('AccessPolicy1') }}"
+          name: "{{ accesspolicy_name | default('AccessPolicy1') }}"
           defaultAction: { "action": "TRUST" }
         path_params:
           domainUUID: "{{ ansible_facts.fmc.domains[0].uuid }}"

--- a/samples/fmc_configuration/samples/access_policy_delete.yml
+++ b/samples/fmc_configuration/samples/access_policy_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete an access policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/samples/deployment.yml
+++ b/samples/fmc_configuration/samples/deployment.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Deploy pending configuration
+  hosts: all
   connection: httpapi
   tasks:
     - name: Get Deployable Devices
@@ -11,7 +13,7 @@
         register_as: devices
 
     - name: Complete playbook when nothing to deploy
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: devices[0].device is undefined
 
     - name: Fetch pending changes
@@ -29,7 +31,7 @@
           version: "{{ devices[0].version }}"
           deviceList:
             - "{{ devices[0].device.id }}"
-          forceDeploy: True
+          forceDeploy: true
         path_params:
           domainUUID: "{{ ansible_facts.fmc.domains[0].uuid }}"
         register_as: deployment_job
@@ -46,6 +48,6 @@
       delay: 3
 
     - name: Stop the playbook if the deployment failed
-      fail:
+      ansible.builtin.fail:
         msg: "Deployment failed. Status: {{ deployment_status[0].status }}"
       when: deployment_status[0].status is not match("SUCCEEDED")

--- a/samples/fmc_configuration/samples/device_registration.yml
+++ b/samples/fmc_configuration/samples/device_registration.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Register a device
+  hosts: all
 
   any_errors_fatal: true
   connection: httpapi
@@ -14,7 +16,7 @@
         #   name: NGFW-Access-Policy27
         register_as: accesspolicy
 
-    - name: device onboarding
+    - name: Device onboarding
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleDevice
         data:

--- a/samples/fmc_configuration/samples/nat.yml
+++ b/samples/fmc_configuration/samples/nat.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create a NAT policy and rule
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -37,9 +39,9 @@
           destinationInterface: "{{ zones[1] }}"
           sourceInterface: "{{ zones[0] }}"
           originalSource: "{{ network_results[0] }}"
-          interfaceInTranslatedSource: True
-          dns: False
-          enabled: True
+          interfaceInTranslatedSource: true
+          dns: false
+          enabled: true
           type: ftdmanualnatrule
         path_params:
           containerUUID: "{{ NAT.id }}"

--- a/samples/fmc_configuration/samples/natpolicy_delete.yml
+++ b/samples/fmc_configuration/samples/natpolicy_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a NAT policy
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/samples/security_zone_delete.yml
+++ b/samples/fmc_configuration/samples/security_zone_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a security zone
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/samples/security_zones.yml
+++ b/samples/fmc_configuration/samples/security_zones.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create security zones
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -12,7 +14,7 @@
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleSecurityZoneObject
         data:
-          name: "{{securityzone1_name | default('secz1') }}"
+          name: "{{ securityzone1_name | default('secz1') }}"
           interfaceMode: ROUTED
           type: SecurityZone
         path_params:
@@ -22,7 +24,7 @@
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleSecurityZoneObject
         data:
-          name: "{{securityzone2_name | default('secz2') }}"
+          name: "{{ securityzone2_name | default('secz2') }}"
           interfaceMode: ROUTED
           type: SecurityZone
         path_params:

--- a/samples/fmc_configuration/security_zone_delete.yml
+++ b/samples/fmc_configuration/security_zone_delete.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Delete a security zone
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/security_zones_create.yml
+++ b/samples/fmc_configuration/security_zones_create.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create security zones
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -12,7 +14,7 @@
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleSecurityZoneObject
         data:
-          name: "{{securityzone_name | default('secz1') }}"
+          name: "{{ securityzone_name | default('secz1') }}"
           interfaceMode: ROUTED
           type: SecurityZone
         path_params:

--- a/samples/fmc_configuration/static_route.yml
+++ b/samples/fmc_configuration/static_route.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Create a static route
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml

--- a/samples/fmc_configuration/sub_interfaces.yml
+++ b/samples/fmc_configuration/sub_interfaces.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Configure subinterfaces
+  hosts: all
   connection: httpapi
   vars_files:
     - vars.yml
@@ -27,9 +29,9 @@
           subIntfId: 1
           ipv4:
             dhcp:
-              enableDefaultRouteDHCP: True
+              enableDefaultRouteDHCP: true
               dhcpRouteMetric: 100
-          enabled: True
+          enabled: true
           vlanId: 101
           MTU: 1500
           mode: NONE
@@ -49,7 +51,7 @@
             static:
               address: "{{ subinterface_ip | default('192.168.5.15') }}"
               netmask: "{{ subinterface_netmask | default('255.255.255.0') }}"
-          enabled: True
+          enabled: true
           vlanId: 102
           MTU: 1500
           mode: NONE

--- a/samples/test_duplicate_network_object.yml
+++ b/samples/test_duplicate_network_object.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test duplicate network object handling
+  hosts: all
   connection: httpapi
 
   tasks:
@@ -8,25 +10,26 @@
         register_as: cra1
 
     # sanity: ensure network object doesn't exist
-    - name: get network object
+    - name: Get network object
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
-          #this filter will return all networks that contain "ansible-test-dup-no"
+          # this filter will return all networks that contain "ansible-test-dup-no"
           filter: "nameOrValue:ansible-test-dup-no"
         register_as: "getObjs"
       register: result
-    - assert:
+    - name: Verify the expected network objects exist
+      ansible.builtin.assert:
         that:
           - getObjs | length == 7
 
-    - name: createMultipleNetworkObject should create multiple new networks
+    - name: CreateMultipleNetworkObject should create multiple new networks
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           bulk: true
         data:
@@ -40,16 +43,17 @@
             type: "networkobject"
         register_as: "createdObjs"
       register: result
-    - assert:
+    - name: Verify both network objects were created
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - createdObjs | length == 2
 
-    - name: createMultipleNetworkObject should quietly succeed with the existing network object when they are identical
+    - name: CreateMultipleNetworkObject should quietly succeed with the existing network object when they are identical
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-dup-no1"
           description: "Create network object"
@@ -57,16 +61,17 @@
           type: "networkobject"
         register_as: "duplicateObj1"
       register: result
-    - assert:
+    - name: Verify an identical object is unchanged
+      ansible.builtin.assert:
         that:
           - result.changed == false
           - createdObjs[0].name == duplicateObj1.name
 
-    - name: createMultipleNetworkObject should quietly succeed with no change to the existing network object when they are identical
+    - name: CreateMultipleNetworkObject should quietly succeed with no change to the existing network object when they are identical
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-dup-no1"
           description: "Create network object"
@@ -74,17 +79,18 @@
           type: "networkobject"
         register_as: "duplicateObj1"
       register: result
-    - assert:
+    - name: Verify repeated identical creation is unchanged
+      ansible.builtin.assert:
         that:
           - result.changed == false
           - createdObjs[0].name == duplicateObj1.name
 
-    - name: updateNetworkObject should quietly succeed with no change to the existing network object when they are identical
+    - name: UpdateNetworkObject should quietly succeed with no change to the existing network object when they are identical
       cisco.fmcansible.fmc_configuration:
         operation: updateNetworkObject
         path_params:
-          objectId: '{{ createdObjs[0].id }}'
-          domainUUID: '{{ cra1[0].uuid }}'
+          objectId: "{{ createdObjs[0].id }}"
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-dup-no1"
           description: "Create network object"
@@ -92,16 +98,17 @@
           type: "networkobject"
         register_as: "duplicateObj1"
       register: result
-    - assert:
+    - name: Verify an identical update is unchanged
+      ansible.builtin.assert:
         that:
           - result.changed == false
           - createdObjs[0].name == duplicateObj1.name
 
-    - name: createMultipleNetworkObject should raise an error when the network object exists and they they are NOT identical
+    - name: CreateMultipleNetworkObject should raise an error when the network object exists and they they are NOT identical
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-dup-no1"
           description: "A different description here"
@@ -109,17 +116,18 @@
           type: "networkobject"
         register_as: "duplicateObj1"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify a conflicting duplicate is rejected
+      ansible.builtin.assert:
         that:
           - result.changed == false
           - "'already exists.' in result.msg"
 
-    - name: createMultipleNetworkObject should raise an error if any of the objects are duplicates and not identical
+    - name: CreateMultipleNetworkObject should raise an error if any of the objects are duplicates and not identical
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           bulk: true
         data:
@@ -133,21 +141,23 @@
             type: "networkobject"
         register_as: "createdObjs"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify a conflicting bulk duplicate is rejected
+      ansible.builtin.assert:
         that:
           - result.changed == false
           - "'already exists.' in result.msg"
 
     # clean up NetworkObjects
-    - name: deleteNetworkObject should delete the network objects with loop
+    - name: DeleteNetworkObject should delete the network objects with loop
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          objectId: '{{ item.id }}'            
+          domainUUID: "{{ cra1[0].uuid }}"
+          objectId: "{{ item.id }}"
       register: result
-      loop: '{{ createdObjs }}'
-    - assert:
+      loop: "{{ createdObjs }}"
+    - name: Verify the network objects were deleted
+      ansible.builtin.assert:
         that:
           - result.changed == true

--- a/samples/test_fmc_configuration_register_as.yml
+++ b/samples/test_fmc_configuration_register_as.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test response fact registration
+  hosts: all
   connection: httpapi
 
   tasks:
@@ -11,12 +13,13 @@
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: test-network15
           value: 3.3.3.0/24
           type: networkobject
-    - assert:
+    - name: Verify implicit single-object registration
+      ansible.builtin.assert:
         that:
           - Network_test_network15 != None
           - Network_test_network15.name == "test-network15"
@@ -25,13 +28,14 @@
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: test-network16
           value: 192.23.23.0/24
           type: networkobject
         register_as: test_network
-    - assert:
+    - name: Verify explicit single-object registration
+      ansible.builtin.assert:
         that:
           - test_network != None
           - test_network.name  == "test-network16"
@@ -40,7 +44,7 @@
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           filter: "nameOrValue:test-network15"
 
@@ -48,28 +52,29 @@
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           filter: "nameOrValue:test-network16"
         register_as: networks
-    - assert:
-       that:
-         - networks != None
-         - networks | length == 1
-         - networks.0.name == "test-network16"
+    - name: Verify explicit list registration
+      ansible.builtin.assert:
+        that:
+          - networks != None
+          - networks | length == 1
+          - networks.0.name == "test-network16"
 
     - name: Delete created Network Object
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
           objectId: "{{ test_network.id }}"
 
     - name: Get network object that was created without register_as
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           filter: "nameOrValue:test-network15"
         register_as: "getObjs"
@@ -78,5 +83,5 @@
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
           objectId: "{{ getObjs[0].id }}"

--- a/samples/test_fmc_configuration_register_as_upsert.yml
+++ b/samples/test_fmc_configuration_register_as_upsert.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test upsert response fact registration
+  hosts: all
   connection: httpapi
 
   tasks:
@@ -11,12 +13,13 @@
       cisco.fmcansible.fmc_configuration:
         operation: upsertNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: test-network6
           value: 3.3.3.0/24
           type: networkobject
-    - assert:
+    - name: Verify implicit upsert registration
+      ansible.builtin.assert:
         that:
           - Network_test_network6 != None
           - Network_test_network6.name == "test-network6"
@@ -25,13 +28,14 @@
       cisco.fmcansible.fmc_configuration:
         operation: upsertNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: test-network8
           value: 192.23.23.0/24
           type: networkobject
         register_as: test_network
-    - assert:
+    - name: Verify explicit upsert registration
+      ansible.builtin.assert:
         that:
           - test_network != None
           - test_network.name  == "test-network8"
@@ -40,7 +44,7 @@
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           filter: "nameOrValue:test-network6"
 
@@ -48,19 +52,20 @@
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           filter: "nameOrValue:test-network8"
         register_as: networks
-    - assert:
-       that:
-         - networks != None
-         - networks | length == 1
-         - networks.0.name == "test-network8"
+    - name: Verify explicit upsert list registration
+      ansible.builtin.assert:
+        that:
+          - networks != None
+          - networks | length == 1
+          - networks.0.name == "test-network8"
 
     - name: Delete created Network Object
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
           objectId: "{{ test_network.id }}"

--- a/samples/test_fmc_configuration_validation.yml
+++ b/samples/test_fmc_configuration_validation.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test FMC request validation
+  hosts: all
   connection: httpapi
 
   tasks:
@@ -7,47 +9,47 @@
         operation: getAllDomain
         register_as: cra1
 
-    - name: getAllNetworkObject with invalid query_params should raise an error
+    - name: GetAllNetworkObject with invalid query_params should raise an error
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
-          offset: True
+          offset: true
           sort: 0
           filter: 1.1
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify invalid query parameter types are rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - '"Invalid query_params provided" in result.msg'
           - '2 == result.msg["Invalid query_params provided"]["invalid_type"] | length'
-          - '{"actually_value": true, "expected_type": "integer", "path": "offset"}
-                              in result.msg["Invalid query_params provided"]["invalid_type"]'
-          - '{"actually_value": 1.1, "expected_type": "string", "path": "filter"}
-                              in result.msg["Invalid query_params provided"]["invalid_type"]'
+          - '{"actually_value": true, "expected_type": "integer", "path": "offset"} in result.msg["Invalid query_params provided"]["invalid_type"]'
+          - '{"actually_value": 1.1, "expected_type": "string", "path": "filter"} in result.msg["Invalid query_params provided"]["invalid_type"]'
 
-    - name: getAllNetworkObject with valid query_params should succeed
+    - name: GetAllNetworkObject with valid query_params should succeed
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           offset: 10
-          limit: '2'
+          limit: "2"
       register: result
-    - assert:
+    - name: Verify valid query parameter types are accepted
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == false'
+          - "result.changed == false"
+          - "result.failed == false"
 
-    - name: createMultipleAccessRule with missing path_params should raise an error
+    - name: CreateMultipleAccessRule with missing path_params should raise an error
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleAccessRule
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-accessrule-val1"
           type: "accessrule"
@@ -55,14 +57,15 @@
           eventLogAction: "LOG_BOTH"
         register_as: "sameRuleObj"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify missing path parameters are rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - 'result.msg == {"Invalid path_params provided": {"required": ["containerUUID"]}}'
 
-    - name: createMultipleAccessRule with invalid path_params should raise an error
+    - name: CreateMultipleAccessRule with invalid path_params should raise an error
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleAccessRule
         data:
@@ -72,52 +75,55 @@
           eventLogAction: "LOG_BOTH"
         path_params:
           parentId: 1
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         register_as: "sameRuleObj"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify invalid path parameter types are rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - '1 == result.msg["Invalid path_params provided"] | length'
           - 'result.msg == {"Invalid path_params provided": {"required": ["containerUUID"]}}'
 
-    - name: updateNetworkObject with missing path_params should raise an error
+    - name: UpdateNetworkObject with missing path_params should raise an error
       cisco.fmcansible.fmc_configuration:
         operation: updateNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-network-val1"
         register_as: "updatedTestObj"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify missing request data is rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - 'result.msg == {"Invalid path_params provided": {"required": ["objectId"]}}'
 
-    - name: deleteNetworkObject with missing path_params should raise an error
+    - name: DeleteNetworkObject with missing path_params should raise an error
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
           test: "testId"
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify unknown request fields are rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - 'result.msg == {"Invalid path_params provided": {"required": ["objectId"]}}'
 
-    - name: is_not_exist operation should NOT be present in the Swagger API
+    - name: Is_not_exist operation should NOT be present in the Swagger API
       cisco.fmcansible.fmc_configuration:
         operation: is_not_exist
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-network-val2"
           description: "Ansible Integration tests in action"
@@ -125,11 +131,12 @@
           type: "networkobject"
         register_as: "testObj"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify invalid nested request fields are rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - "result.msg == 'Invalid operation name provided: is_not_exist'"
 
 # need to check this test as it is giving module std error
@@ -153,11 +160,11 @@
 #           - 'result.msg == {"Invalid data provided": {"required": ["name", "type", "value"]}}'
 #       tags: skip-on-6.2.3
 
-    - name: createMultipleNetworkObject should raise an error when invalid data provided
+    - name: CreateMultipleNetworkObject should raise an error when invalid data provided
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: false
           description: true
@@ -165,26 +172,23 @@
           type: 1
         register_as: "testObj"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify invalid object field types are rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - '4 == result.msg["Invalid data provided"]["invalid_type"] | length'
-          - '{"actually_value": false, "expected_type": "string", "path": "name"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
-          - '{"actually_value": true, "expected_type": "string", "path": "description"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
-          - '{"actually_value": 0, "expected_type": "string", "path": "value"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
-          - '{"actually_value": 1, "expected_type": "string", "path": "type"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": false, "expected_type": "string", "path": "name"} in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": true, "expected_type": "string", "path": "description"} in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 0, "expected_type": "string", "path": "value"} in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1, "expected_type": "string", "path": "type"} in result.msg["Invalid data provided"]["invalid_type"]'
 
-    - name: createMultipleNetworkObject should raise an error when invalid data provided
+    - name: CreateMultipleNetworkObject should raise an error when invalid data provided
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: 0
           description: 1.2
@@ -192,17 +196,14 @@
           type: 1.1
         register_as: "testObj"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify invalid bulk object field types are rejected
+      ansible.builtin.assert:
         that:
-          - 'result.changed == false'
-          - 'result.failed == true'
+          - "result.changed == false"
+          - "result.failed == true"
           - '4 == result.msg["Invalid data provided"]["invalid_type"] | length'
-          - '{"actually_value": 0, "expected_type": "string", "path": "name"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
-          - '{"actually_value": 1.2, "expected_type": "string", "path": "description"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
-          - '{"actually_value": 1, "expected_type": "string", "path": "value"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
-          - '{"actually_value": 1.1, "expected_type": "string", "path": "type"}
-                              in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 0, "expected_type": "string", "path": "name"} in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1.2, "expected_type": "string", "path": "description"} in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1, "expected_type": "string", "path": "value"} in result.msg["Invalid data provided"]["invalid_type"]'
+          - '{"actually_value": 1.1, "expected_type": "string", "path": "type"} in result.msg["Invalid data provided"]["invalid_type"]'

--- a/samples/test_idempotency_access_rule.yml
+++ b/samples/test_idempotency_access_rule.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test access rule idempotency
+  hosts: all
   connection: httpapi
   tasks:
     - name: Get all domain for Cisco FMC
@@ -6,11 +8,11 @@
         operation: getAllDomain
         register_as: cra1
 
-    - name: create auxiliary network object
+    - name: Create auxiliary network object
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-network-ar1"
           value: "192.22.22.0/24"
@@ -21,10 +23,10 @@
       cisco.fmcansible.fmc_configuration:
         operation: getAllIntrusionPolicy
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         register_as: policies
 
-    - name: createAccessPolicy to allow traffic by default
+    - name: CreateAccessPolicy to allow traffic by default
       cisco.fmcansible.fmc_configuration:
         operation: createAccessPolicy
         data:
@@ -38,18 +40,18 @@
           type: AccessPolicy
         register_as: ngfw1
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
 
     # get the access policy that was created in the previous step
-    - name: get Access Policy to be updated
+    - name: Get Access Policy to be updated
       cisco.fmcansible.fmc_configuration:
         operation: getAccessPolicy
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          objectId: '{{ ngfw1.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          objectId: "{{ ngfw1.id }}"
         register_as: acp
 
-    - name: createMultipleAccessRule should create a new access rule
+    - name: CreateMultipleAccessRule should create a new access rule
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleAccessRule
         data:
@@ -57,16 +59,17 @@
           type: "AccessRule"
           action: "ALLOW"
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          containerUUID: '{{ acp.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          containerUUID: "{{ acp.id }}"
         register_as: "testRuleObj"
       register: result
-    - assert:
+    - name: Verify the access rule was created
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - testRuleObj['name'] == "ansible-test-accessrule-ar1"
 
-    - name: createMultipleAccessRule should raise an error when the rule with the same name exists
+    - name: CreateMultipleAccessRule should raise an error when the rule with the same name exists
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleAccessRule
         data:
@@ -74,23 +77,24 @@
           type: "accessrule"
           action: "BLOCK"
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          containerUUID: '{{ acp.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          containerUUID: "{{ acp.id }}"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify a conflicting rule is rejected
+      ansible.builtin.assert:
         that:
           - result.changed == false
           - result.failed == true
           - "'An object with the same name but different parameters already exists' in result.msg"
 
     # Note: prefer using updateAccessRule over updateMultipleAccessRule for single object
-    - name: updateAccessRule should update the existing rule
+    - name: UpdateAccessRule should update the existing rule
       cisco.fmcansible.fmc_configuration:
         operation: updateAccessRule
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          containerUUID: '{{ acp.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          containerUUID: "{{ acp.id }}"
           objectId: "{{ testRuleObj.id }}"
         data:
           name: "ansible-test-accessrule-ar1"
@@ -100,17 +104,18 @@
           # id: "{{ testRuleObj.id }}"
         register_as: "updatedRuleObj"
       register: result
-    - assert:
+    - name: Verify the access rule was updated
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - updatedRuleObj['id'] == testRuleObj['id']
 
-    - name: updateAccessRule should NOT update the rule if there are no changes
+    - name: UpdateAccessRule should NOT update the rule if there are no changes
       cisco.fmcansible.fmc_configuration:
         operation: updateAccessRule
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          containerUUID: '{{ acp.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          containerUUID: "{{ acp.id }}"
           objectId: "{{ testRuleObj.id }}"
         data:
           name: "ansible-test-accessrule-ar1"
@@ -119,12 +124,13 @@
           id: "{{ testRuleObj.id }}"
         register_as: "updatedRuleObj"
       register: result
-    - assert:
+    - name: Verify an identical update is unchanged
+      ansible.builtin.assert:
         that:
           - result.changed == false
-          - updatedRuleObj['id'] == testRuleObj['id']          
-          
-    - name: updateAccessRule should raise a 422 unprocessable error when invalid properties specified
+          - updatedRuleObj['id'] == testRuleObj['id']
+
+    - name: UpdateAccessRule should raise a 422 unprocessable error when invalid properties specified
       cisco.fmcansible.fmc_configuration:
         operation: updateAccessRule
         data:
@@ -135,21 +141,22 @@
           badProperty: true
         path_params:
           objectId: "{{ testRuleObj['id'] }}"
-          domainUUID: '{{ cra1[0].uuid }}'
-          containerUUID: '{{ acp.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          containerUUID: "{{ acp.id }}"
         register_as: "updatedRuleObj"
-      ignore_errors: yes
+      ignore_errors: true
       register: result
-    - assert:
+    - name: Verify invalid rule properties are rejected
+      ansible.builtin.assert:
         that:
           - "'Unprocessable Entity - Unrecognized Field' in result.msg"
 
-    - name: upsertAccessRule should update the existing rule when it exists
+    - name: UpsertAccessRule should update the existing rule when it exists
       cisco.fmcansible.fmc_configuration:
         operation: upsertAccessRule
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          containerUUID: '{{ acp.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          containerUUID: "{{ acp.id }}"
         data:
           name: "ansible-test-accessrule-ar1"
           type: "accessrule"
@@ -161,34 +168,36 @@
           action: "ALLOW"
         register_as: "upsertedRuleObj"
       register: result
-    - assert:
+    - name: Verify upsert updated the access rule
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - upsertedRuleObj['id'] == testRuleObj['id']
           - upsertedRuleObj['action'] == "ALLOW"
 
-    - name: deleteAccessRule should delete the rule
+    - name: DeleteAccessRule should delete the rule
       cisco.fmcansible.fmc_configuration:
         operation: deleteAccessRule
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          containerUUID: '{{ acp.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          containerUUID: "{{ acp.id }}"
           objectId: "{{ testRuleObj['id'] }}"
       register: result
-    - assert:
+    - name: Verify the access rule was deleted
+      ansible.builtin.assert:
         that:
           - result.changed == true
 
-    - name: delete access policy
+    - name: Delete access policy
       cisco.fmcansible.fmc_configuration:
         operation: deleteAccessPolicy
         path_params:
           objectId: "{{ acp.id }}"
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
 
-    - name: delete auxiliary network object
+    - name: Delete auxiliary network object
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
           objectId: "{{ testNetworkObj['id'] }}"
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"

--- a/samples/test_idempotency_network_object.yml
+++ b/samples/test_idempotency_network_object.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test network object idempotency
+  hosts: all
   connection: httpapi
 
   tasks:
@@ -7,11 +9,11 @@
         operation: getAllDomain
         register_as: cra1
 
-    - name: createMultipleNetworkObject should create a new network
+    - name: CreateMultipleNetworkObject should create a new network
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'        
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-network-no2"
           description: "Ansible Integration tests in action"
@@ -19,35 +21,37 @@
           type: "networkobject"
         register_as: "testObj"
       register: result
-    - assert:
+    - name: Verify the network object was created
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - testObj['name'] == "ansible-test-network-no2"
 
-    - name: createMultipleNetworkObject should raise an error when the network with the same name but different params exists
+    - name: CreateMultipleNetworkObject should raise an error when the network with the same name but different params exists
       cisco.fmcansible.fmc_configuration:
         operation: createMultipleNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'        
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-network-no2"
           description: "Ansible Integration tests in action. Change #1"
           value: "3.3.3.0/24"
           type: "networkobject"
       register: result
-      ignore_errors: yes
-    - assert:
+      ignore_errors: true
+    - name: Verify a conflicting network object is rejected
+      ansible.builtin.assert:
         that:
           - result.changed == false
           - result.failed == true
           - "'An object with the same name but different parameters already exists' in result.msg"
 
-    - name: updateNetworkObject should update the existing network when it exists
+    - name: UpdateNetworkObject should update the existing network when it exists
       cisco.fmcansible.fmc_configuration:
         operation: updateNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          objectId: '{{ testObj.id }}'        
+          domainUUID: "{{ cra1[0].uuid }}"
+          objectId: "{{ testObj.id }}"
         data:
           name: "ansible-test-network-no2"
           description: "Ansible Integration tests in action. Change #2"
@@ -57,30 +61,33 @@
           # id: '{{ testObj.id }}'
         register_as: "updatedTestObj"
       register: result
-    - assert:
+    - name: Verify the network object was updated
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - updatedTestObj['id'] == testObj['id']
           - updatedTestObj['value'] == "3.3.3.0/24"
 
-    - name: deleteNetworkObject should delete the network object
+    - name: DeleteNetworkObject should delete the network object
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          objectId: '{{ testObj.id }}'            
+          domainUUID: "{{ cra1[0].uuid }}"
+          objectId: "{{ testObj.id }}"
       register: result
-    - assert:
+    - name: Verify the network object was deleted
+      ansible.builtin.assert:
         that:
           - result.changed == true
 
-    - name: deleteNetworkObject should quietly succeed when the referenced network does not exist
+    - name: DeleteNetworkObject should quietly succeed when the referenced network does not exist
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          objectId: '{{ testObj.id }}'
+          domainUUID: "{{ cra1[0].uuid }}"
+          objectId: "{{ testObj.id }}"
       register: result
-    - assert:
+    - name: Verify repeated deletion is unchanged
+      ansible.builtin.assert:
         that:
           - result.changed == false

--- a/samples/test_nat.yml
+++ b/samples/test_nat.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test NAT policy creation
+  hosts: all
   connection: httpapi
   tasks:
     - name: Get all SecurityZone objects
@@ -38,9 +40,9 @@
           destinationInterface: "{{ zones[0] }}"
           sourceInterface: "{{ zones[1] }}"
           originalSource: "{{ network_results[0] }}"
-          interfaceInTranslatedSource: True
-          dns: False
-          enabled: True
+          interfaceInTranslatedSource: true
+          dns: false
+          enabled: true
           type: FTDManualNatRule
         path_params:
           containerUUID: "{{ natpolicy.id }}"

--- a/samples/test_upsert_network_object.yml
+++ b/samples/test_upsert_network_object.yml
@@ -1,4 +1,6 @@
-- hosts: all
+---
+- name: Test network object upsert
+  hosts: all
   connection: httpapi
 
   tasks:
@@ -8,25 +10,26 @@
         register_as: cra1
 
     # sanity: ensure network object doesn't exist
-    - name: get network object
+    - name: Get network object
       cisco.fmcansible.fmc_configuration:
         operation: getAllNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         query_params:
           filter: "nameOrValue:ansible-test-upsert-no5"
         register_as: "getObjs"
       register: result
-    - assert:
+    - name: Verify the network object does not exist
+      ansible.builtin.assert:
         that:
           - getObjs | length == 0
 
     # create NetworkObject via upsert
-    - name: upsertNetworkObject should create a new network
+    - name: UpsertNetworkObject should create a new network
       cisco.fmcansible.fmc_configuration:
         operation: upsertNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'        
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-upsert-no5"
           description: "Upserted network object"
@@ -34,17 +37,18 @@
           type: "networkobject"
         register_as: "upsertedObj"
       register: result
-    - assert:
+    - name: Verify upsert created the network object
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - upsertedObj['name'] == "ansible-test-upsert-no5"
 
     # update NetworkObject via upsert
-    - name: upsertNetworkObject should update the existing network object
+    - name: UpsertNetworkObject should update the existing network object
       cisco.fmcansible.fmc_configuration:
         operation: upsertNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
+          domainUUID: "{{ cra1[0].uuid }}"
         data:
           name: "ansible-test-upsert-no5"
           description: "Ansible Integration tests in action"
@@ -52,20 +56,22 @@
           type: "networkobject"
         register_as: "upsertedObj2"
       register: result
-    - assert:
+    - name: Verify upsert updated the network object
+      ansible.builtin.assert:
         that:
           - result.changed == true
           - upsertedObj2['id'] == upsertedObj['id']
           - upsertedObj2['value'] == "4.4.4.0/24"
 
     # clean up NetworkObject
-    - name: deleteNetworkObject should delete the network object
+    - name: DeleteNetworkObject should delete the network object
       cisco.fmcansible.fmc_configuration:
         operation: deleteNetworkObject
         path_params:
-          domainUUID: '{{ cra1[0].uuid }}'
-          objectId: '{{ upsertedObj.id }}'            
+          domainUUID: "{{ cra1[0].uuid }}"
+          objectId: "{{ upsertedObj.id }}"
       register: result
-    - assert:
+    - name: Verify the upserted network object was deleted
+      ansible.builtin.assert:
         that:
           - result.changed == true

--- a/samples/upgrade_ftd_ha_pairs/ftd-ha-upgrade.yml
+++ b/samples/upgrade_ftd_ha_pairs/ftd-ha-upgrade.yml
@@ -3,9 +3,6 @@
   hosts: fmc
 
   connection: httpapi
-  collections:
-    - cisco.fmcansible
-
   vars_files:
     - vars.yml
 
@@ -21,7 +18,7 @@
         register_as: pkg_list
 
     - name: Select package by name
-      set_fact:
+      ansible.builtin.set_fact:
         upgrade_pkg: >-
           {{ pkg_list
             | selectattr('name','issuperset', version)
@@ -38,20 +35,20 @@
       register: all_devices_in_ha
 
     - name: Build targets list from names
-      set_fact:
+      ansible.builtin.set_fact:
         targets: |-
           [{% for name in ha_pair_names %}
-            { "id": "{{ (all_devices_in_ha.response.get('items', []) | selectattr('name','equalto', name) | list | first).id }}",
+            { "id": "{{ (all_devices_in_ha.response.get('items', []) | selectattr('name', 'equalto', name) | list | first).id }}",
               "type": "HAContainer",
               "name": "{{ name }}" }{{ "," if not loop.last else "" }}{% endfor %}]
 
     - name: Build target devices list from names
-      set_fact:
+      ansible.builtin.set_fact:
         target_devices: |-
           [{% for name in ha_pair_names %}
-            { "id": "{{ (all_devices_in_ha.response.get('items', []) | selectattr('name','equalto', name) | list | first).primary.id }}",
+            { "id": "{{ (all_devices_in_ha.response.get('items', []) | selectattr('name', 'equalto', name) | list | first).primary.id }}",
               "type": "Device",
-              "name": "{{ (all_devices_in_ha.response.get('items', []) | selectattr('name','equalto', name) | list | first).primary.name }}" },
+              "name": "{{ (all_devices_in_ha.response.get('items', []) | selectattr('name', 'equalto', name) | list | first).primary.name }}" },
               {{ "," if not loop.last else "" }}{% endfor %}]
 
     - name: Create backup of devices
@@ -77,16 +74,15 @@
       delay: 30
 
     - name: Verify backup success
-      assert:
+      ansible.builtin.assert:
         that: backup_status.status == "COMPLETED"
         fail_msg: "Backup failed: {{ backup_status.error | default('Unknown error') }}"
         success_msg: "Backup completed successfully for {{ ha_pair_names | length }} HA Pair(s)!"
 
     - name: About the Readiness Check
-      debug:
-        msg:
-          "Starting readiness check for upgrade package '{{ upgrade_pkg.name }}' on HA devices: {{ ha_pair_names | join(', ') }}.
-          The readiness check identifies issues including database integrity, version inconsistencies, and device registration. Do not reboot or shut down an appliance during the readiness check."
+      ansible.builtin.debug:
+        msg: "Starting readiness check for upgrade package '{{ upgrade_pkg.name }}' on HA devices: {{ ha_pair_names | join(', ') }}. The readiness check identifies
+          issues including database integrity, version inconsistencies, and device registration. Do not reboot or shut down an appliance during the readiness check."
 
     - name: Start readiness check
       cisco.fmcansible.fmc_configuration:
@@ -113,7 +109,7 @@
       delay: 60
 
     - name: Fail if readiness failed
-      fail:
+      ansible.builtin.fail:
         msg: "Readiness check failed: {{ readiness_status }}"
       when: readiness_status.status == "FAILED"
 
@@ -142,7 +138,7 @@
       delay: 60
 
     - name: Show upgrade outcome
-      debug:
+      ansible.builtin.debug:
         msg:
           - "Upgrade Status: {{ upgrade_status.status }}"
           - "Errors/Warnings: {{ upgrade_status.message | default('None') }}"

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -33,12 +33,12 @@ try:
     # Allow wildcard import because we really do want to import all of mock's
     # symbols into this compat shim
     # pylint: disable=wildcard-import,unused-wildcard-import
-    from unittest.mock import *
+    from unittest.mock import *  # noqa: F403
 except ImportError:
     # Python 2
     # pylint: disable=wildcard-import,unused-wildcard-import
     try:
-        from mock import *
+        from mock import *  # noqa: F403
     except ImportError:
         print('You need the mock library installed on python2.x to run tests')
 
@@ -52,7 +52,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
         # Retrieve lines from read_data via a generator so that separate calls to
         # readline, read, and readlines are properly interleaved
         sep = b'\n' if isinstance(read_data, bytes) else '\n'
-        data_as_list = [l + sep for l in read_data.split(sep)]
+        data_as_list = [line + sep for line in read_data.split(sep)]
 
         if data_as_list[-1] == sep:
             # If the last line ended in a newline, the list comprehension will have an
@@ -105,9 +105,9 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             file_spec = list(set(dir(_io.TextIOWrapper)).union(set(dir(_io.BytesIO))))
 
         if mock is None:
-            mock = MagicMock(name='open', spec=open)
+            mock = MagicMock(name='open', spec=open)  # noqa: F405
 
-        handle = MagicMock(spec=file_spec)
+        handle = MagicMock(spec=file_spec)  # noqa: F405
         handle.__enter__.return_value = handle
 
         _data = _iterate_read_data(read_data)

--- a/tests/unit/compat/unittest.py
+++ b/tests/unit/compat/unittest.py
@@ -31,8 +31,8 @@ import sys
 if sys.version_info < (2, 7):
     try:
         # Need unittest2 on python2.6
-        from unittest2 import *
+        from unittest2 import *  # noqa: F401,F403
     except ImportError:
         print('You need unittest2 installed on python2.6.x to run tests')
 else:
-    from unittest import *
+    from unittest import *  # noqa: F401,F403

--- a/tests/unit/httpapi_plugins/test_fmc.py
+++ b/tests/unit/httpapi_plugins/test_fmc.py
@@ -22,11 +22,11 @@ __metaclass__ = type
 
 import json
 import unittest
+from io import BytesIO, StringIO
+from urllib.error import HTTPError
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.connection import ConnectionError
-from ansible.module_utils.six import PY3, BytesIO, StringIO
-from ansible.module_utils.six.moves.urllib.error import HTTPError
 
 try:
     from unittest import mock
@@ -43,10 +43,7 @@ from ansible_collections.cisco.fmcansible.plugins.module_utils.common import (
 from ansible_collections.cisco.fmcansible.plugins.module_utils.fmc_swagger_client import (
     FmcSwaggerParser, SpecProp)
 
-if PY3:
-    BUILTINS_NAME = 'builtins'
-else:
-    BUILTINS_NAME = '__builtin__'
+BUILTINS_NAME = 'builtins'
 
 
 class FakeFmcHttpApiPlugin(HttpApi):

--- a/tests/unit/module_utils/test_upsert_functionality.py
+++ b/tests/unit/module_utils/test_upsert_functionality.py
@@ -183,7 +183,7 @@ class TestUpsertOperationUnitTests(unittest.TestCase):
         find_object.return_value = existing_obj
         equal_objects_mock.return_value = True
 
-        result = self._resource.upsert_object('upsertFoo', params)
+        self._resource.upsert_object('upsertFoo', params)
 
         # assert result == existing_obj
         self._conn.get_model_spec.assert_called_once_with('Foo')


### PR DESCRIPTION
Document the authentication recovery, GETALL query routing, and Swagger free-form object validation fixes. 
Clean the Galaxy artifact and update Python and Ansible content for current sanity, flake8, and ansible-lint checks.