### PR TITLE
Fix release validation workflow

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,218 +1,232 @@
+---
 name: CI
+
 on:
-  # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
   push:
+    branches:
+      - develop
+      - main
   pull_request:
+    branches:
+      - develop
+      - main
   workflow_dispatch:
-  # Run CI once per day (at 06:00 UTC)
-  # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
-  schedule:
-    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NAMESPACE: cisco
   COLLECTION_NAME: fmcansible
 
 jobs:
-
-###
-# Check Build
-#
-
-
   build:
-    name: Build collection
+    name: Build/install (core ${{ matrix.ansible }}, Python ${{ matrix.python }})
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
-        # ansible: [2.9.17, 2.10.5]
-        # ansible: [2.18.3, 2.17.9, 2.16.14]
-        ansible: [2.18.3]
+        include:
+          - ansible: 2.16.19
+            python: "3.12"
+          - ansible: 2.17.14
+            python: "3.12"
+          - ansible: 2.18.18
+            python: "3.13"
+          - ansible: 2.19.11
+            python: "3.13"
+          - ansible: 2.20.7
+            python: "3.14"
+          - ansible: 2.21.3
+            python: "3.14"
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
-    
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
+      - name: Check out code
+        uses: actions/checkout@v4
 
-    - name: Install ansible-core
-      run: pip install ansible-core --force-reinstall
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
 
-    - name: Install ansible-base (v${{ matrix.ansible }})
-      run: pip install https://github.com/ansible/ansible/archive/v${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+      - name: Install ansible-core ${{ matrix.ansible }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "ansible-core==${{ matrix.ansible }}"
 
-    - name: Build a collection tarball
-      run: pwd && ls -al && find . && ansible-galaxy collection build --output-path "${GITHUB_WORKSPACE}/.cache/collection-tarballs"
+      - name: Build collection
+        run: >-
+          ansible-galaxy collection build
+          --output-path "${GITHUB_WORKSPACE}/.cache/collection-tarballs"
 
-    - name: Store migrated collection artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: collection-2.18.3
-        path: .cache/collection-tarballs
+      - name: Install and load collection
+        env:
+          ANSIBLE_COLLECTIONS_PATH: ${{ runner.temp }}/collections
+        run: |
+          ansible-galaxy collection install \
+            .cache/collection-tarballs/cisco-*.tar.gz \
+            --force \
+            --collections-path "${ANSIBLE_COLLECTIONS_PATH}"
+          ansible-doc cisco.fmcansible.fmc_configuration >/dev/null
+          ansible-doc cisco.fmcansible.fmc_facts >/dev/null
+          ansible-doc --type httpapi cisco.fmcansible.fmc >/dev/null
 
-###
-# Check Importer
-#
+      - name: Store release artifact
+        if: matrix.ansible == '2.21.3'
+        uses: actions/upload-artifact@v4
+        with:
+          name: collection-release
+          path: .cache/collection-tarballs/cisco-*.tar.gz
+          if-no-files-found: error
 
   importer:
-    name: Galaxy-importer check
+    name: Galaxy importer
     needs:
-    - build
-    runs-on: ubuntu-latest
+      - build
+    runs-on: ubuntu-22.04
     steps:
-    - name: Check out code
-      uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-    - name: Install ansible-base (v2.18.3)
-      run: pip install https://github.com/ansible/ansible/archive/v2.18.3.tar.gz --disable-pip-version-check
+      - name: Install importer
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            "ansible-core==2.21.3" \
+            "galaxy-importer==0.4.41"
 
-    - name: Download migrated collection artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: collection-2.18.3
-        path: .cache/collection-tarballs
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: collection-release
+          path: .cache/collection-tarballs
 
-    - name: Install the collection tarball
-      run: ansible-galaxy collection install .cache/collection-tarballs/*.tar.gz
+      - name: Install collection
+        run: >-
+          ansible-galaxy collection install
+          .cache/collection-tarballs/cisco-*.tar.gz
+          --force
 
-    - name: Install galaxy-importer
-      run: pip install galaxy-importer
+      - name: Run Galaxy importer
+        env:
+          GALAXY_IMPORTER_CONFIG: ${{ github.workspace }}/.github/workflows/galaxy-importer.cfg
+        run: |
+          set -o pipefail
+          python -m galaxy_importer.main \
+            .cache/collection-tarballs/cisco-*.tar.gz \
+            | tee .cache/collection-tarballs/importer.log
+          cp importer_result.json \
+            .cache/collection-tarballs/importer_result.json
 
-    - name: Run galaxy-importer check
-      env:
-        GALAXY_IMPORTER_CONFIG: ${{ github.workspace }}/.github/workflows/galaxy-importer.cfg
-      run: |
-        set -o pipefail
-        python -m galaxy_importer.main .cache/collection-tarballs/cisco-*.tar.gz | tee .cache/collection-tarballs/log.txt
-        cp ./importer_result.json .cache/collection-tarballs/importer_result.json
-
-    - name: Check warnings and errors
-      run: if grep -E 'ERROR' .cache/collection-tarballs/log.txt; then exit 1; else exit 0; fi
-
-    - name: Store galaxy_importer check log file
-      uses: actions/upload-artifact@v4
-      with:
-        name: galaxy-importer-log
-        path: .cache/collection-tarballs/importer_result.json
-
-###
-# Sanity tests (REQUIRED)
-#
-# https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
+      - name: Store importer results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: galaxy-importer-results
+          path: |
+            .cache/collection-tarballs/importer.log
+            .cache/collection-tarballs/importer_result.json
+          if-no-files-found: warn
 
   sanity:
-    name: Sanity (Ⓐ${{ matrix.ansible }})
-    strategy:
-      matrix:
-        ansible:
-          # - stable-2.9
-          # - stable-2.10
-          # - stable-2.16
-          - stable-2.17
-          - stable-2.18
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
+    name: Sanity (core ${{ matrix.ansible }}, Python ${{ matrix.python }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ansible: 2.16.19
+            python: "3.12"
+          - ansible: 2.17.14
+            python: "3.12"
+          - ansible: 2.18.18
+            python: "3.13"
+          - ansible: 2.19.11
+            python: "3.13"
+          - ansible: 2.20.7
+            python: "3.14"
+          - ansible: 2.21.3
+            python: "3.14"
     steps:
-
-      # ansible-test requires the collection to be in a directory in the form
-      # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
-
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+          path: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
-          # it is just required to run that once as "ansible-test sanity" in the docker image
-          # will run on all python versions it supports.
-          python-version: '3.11'
+          python-version: ${{ matrix.python }}
 
-      - name: Install dependencies
+      - name: Install ansible-core ${{ matrix.ansible }}
         run: |
           python -m pip install --upgrade pip
-          # Install urllib3 directly if it's a direct dependency
-          pip install urllib3
-
-      # Install the head of the given branch (devel, stable-2.10)
-      - name: Install ansible-base (${{ matrix.ansible }})
-        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+          python -m pip install "ansible-core==${{ matrix.ansible }}"
 
       - name: Run sanity tests
+        working-directory: >-
+          ./ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
         run: ansible-test sanity --docker -v --color
-        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
-
-      # ansible-test support producing code coverage date
-      - name: Generate coverage report
-        # run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
-
-      # See the reports at https://codecov.io/gh/GITHUBORG/REPONAME
-      - uses: codecov/codecov-action@v5
-        with:
-          fail_ci_if_error: false
-
-###
-# Unit tests (REQUIRED)
-#
-# https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html
 
   units:
-    name: Unit (Ⓐ${{ matrix.ansible }})
-    strategy:
-      matrix:
-        ansible:
-          # - stable-2.9
-          # - stable-2.10
-          # - stable-2.16
-          - stable-2.17
-          - stable-2.18
-          # It's important that Sanity is tested against all stable-X.Y branches
-          # Testing against `devel` may fail as new tests are added.
-          # - stable-2.9 # Only if your collection supports Ansible 2.9
+    name: Unit (core ${{ matrix.ansible }}, Python ${{ matrix.python }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ansible: 2.16.19
+            python: "3.12"
+          - ansible: 2.17.14
+            python: "3.12"
+          - ansible: 2.18.18
+            python: "3.13"
+          - ansible: 2.19.11
+            python: "3.13"
+          - ansible: 2.20.7
+            python: "3.14"
+          - ansible: 2.21.3
+            python: "3.14"
     steps:
-
-      # ansible-test requires the collection to be in a directory in the form
-      # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
-
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+          path: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5
         with:
-          # it is just required to run that once as "ansible-test sanity" in the docker image
-          # will run on all python versions it supports.
-          python-version: '3.11'
+          python-version: ${{ matrix.python }}
 
-      - name: Install dependencies
+      - name: Install ansible-core ${{ matrix.ansible }}
         run: |
           python -m pip install --upgrade pip
-          # Install urllib3 directly if it's a direct dependency
-          pip install urllib3
+          python -m pip install "ansible-core==${{ matrix.ansible }}"
 
-      # Install the head of the given branch (devel, stable-2.10)
-      - name: Install ansible-base (${{ matrix.ansible }})
-        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
-
-      # Install units
-      # - name: Install units
-      #   run: pip install units
-
-      # Run the unit tests on python 3.5
       - name: Run unit tests
+        working-directory: >-
+          ./ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
         run: ansible-test units --docker -v --color
-        working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
+
+      - name: Generate coverage report
+        if: matrix.ansible == '2.21.3'
+        working-directory: >-
+          ./ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
+        run: >-
+          ansible-test coverage xml
+          --group-by command
+          --group-by version
+
+      - name: Upload coverage
+        if: matrix.ansible == '2.21.3'
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -222,6 +222,7 @@ jobs:
           ./ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
         run: >-
           ansible-test coverage xml
+          --requirements
           --group-by command
           --group-by version
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -3,6 +3,7 @@ on:
   # Run CI against all pushes (direct commits, also merged PRs), Pull Requests
   push:
   pull_request:
+  workflow_dispatch:
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
   schedule:
@@ -28,7 +29,7 @@ jobs:
         ansible: [2.18.3]
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
@@ -47,7 +48,7 @@ jobs:
     - name: Store migrated collection artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: collection-${{ strategy.index }}
+        name: collection-2.18.3
         path: .cache/collection-tarballs
 
 ###
@@ -60,8 +61,11 @@ jobs:
     - build
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Python 3.11
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
@@ -71,8 +75,7 @@ jobs:
     - name: Download migrated collection artifacts
       uses: actions/download-artifact@v4
       with:
-        name: collection-${{ strategy.index }}
-        merge-multiple: true
+        name: collection-2.18.3
         path: .cache/collection-tarballs
 
     - name: Install the collection tarball
@@ -81,14 +84,13 @@ jobs:
     - name: Install galaxy-importer
       run: pip install galaxy-importer
 
-    - name: Create galaxy-importer directory
-      run: sudo mkdir -p /etc/galaxy-importer
-
-    - name: Create galaxy-importer.cfg
-      run: sudo cp /home/runner/.ansible/collections/ansible_collections/cisco/fmcansible/.github/workflows/galaxy-importer.cfg /etc/galaxy-importer/galaxy-importer.cfg
-
     - name: Run galaxy-importer check
-      run: python -m galaxy_importer.main .cache/collection-tarballs/cisco-*.tar.gz | tee .cache/collection-tarballs/log.txt && sudo cp ./importer_result.json .cache/collection-tarballs/importer_result.json
+      env:
+        GALAXY_IMPORTER_CONFIG: ${{ github.workspace }}/.github/workflows/galaxy-importer.cfg
+      run: |
+        set -o pipefail
+        python -m galaxy_importer.main .cache/collection-tarballs/cisco-*.tar.gz | tee .cache/collection-tarballs/log.txt
+        cp ./importer_result.json .cache/collection-tarballs/importer_result.json
 
     - name: Check warnings and errors
       run: if grep -E 'ERROR' .cache/collection-tarballs/log.txt; then exit 1; else exit 0; fi
@@ -96,7 +98,7 @@ jobs:
     - name: Store galaxy_importer check log file
       uses: actions/upload-artifact@v4
       with:
-        name: galaxy-importer-log-${{ strategy.index }}
+        name: galaxy-importer-log
         path: .cache/collection-tarballs/importer_result.json
 
 ###
@@ -124,12 +126,12 @@ jobs:
       # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
@@ -156,7 +158,7 @@ jobs:
         working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       # See the reports at https://codecov.io/gh/GITHUBORG/REPONAME
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: false
 
@@ -185,7 +187,7 @@ jobs:
       # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 

--- a/plugins/module_utils/configuration.py
+++ b/plugins/module_utils/configuration.py
@@ -759,9 +759,14 @@ def iterate_over_pageable_resource(resource_func, params):
             break
 
         # ansible-core 2.16 validates module_utils against Python 2.7, where
-        # ``yield from`` is not valid syntax.
-        for item in items:  # pylint: disable=use-yield-from
+        # ``yield from`` is not valid syntax. Using an iterator also avoids a
+        # version-specific pylint suppression.
+        item_iterator = iter(items)
+        sentinel = object()
+        item = next(item_iterator, sentinel)
+        while item is not sentinel:
             yield item
+            item = next(item_iterator, sentinel)
 
         if received_less_items_than_requested(len(items), limit):
             break

--- a/plugins/module_utils/configuration.py
+++ b/plugins/module_utils/configuration.py
@@ -758,9 +758,10 @@ def iterate_over_pageable_resource(resource_func, params):
         if items is None:
             break
 
-        # for item in items:
-        #     yield item
-        yield from items
+        # ansible-core 2.16 validates module_utils against Python 2.7, where
+        # ``yield from`` is not valid syntax.
+        for item in items:  # pylint: disable=use-yield-from
+            yield item
 
         if received_less_items_than_requested(len(items), limit):
             break

--- a/plugins/module_utils/device.py
+++ b/plugins/module_utils/device.py
@@ -4,62 +4,57 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from abc import ABC
-from enum import Enum
-from urllib.parse import urlparse
-
-# The test mocks these, so we need placeholder imports.
-# In a real scenario, these would be actual library imports.
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 try:
     from kick.device.fp2k.fmc import Kp
     from kick.device.asa5500x.fmc import Fmc5500x
 except ImportError:
-    from unittest.mock import MagicMock
-
-    # Create dummy classes if 'kick' is not installed,
-    # allowing module to be imported.
-
-    class Kp(object):
+    class _UnavailableKickDevice(object):
         def __init__(self, *args, **kwargs):
-            pass
+            raise ImportError("The 'kick' package is required to install FMC images.")
 
-        def ssh_console(self):
-            mock_console = MagicMock()
-            mock_console.__enter__.return_value = mock_console
-            mock_console.__exit__.return_value = False  # Propagate exceptions
-            return mock_console
-
-    class Fmc5500x(object):
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def ssh_console(self):
-            mock_console = MagicMock()
-            mock_console.__enter__.return_value = mock_console
-            mock_console.__exit__.return_value = False  # Propagate exceptions
-            return mock_console
+    Kp = _UnavailableKickDevice
+    Fmc5500x = _UnavailableKickDevice
 
 
 class FmcConfigurationError(Exception):
     pass
 
 
-class FmcModel(Enum):
-    FMC_1600 = 'FMC-1600'
-    FMC_2110 = 'FMC-2110'
-    FMC_2120 = 'FMC-2120'
-    FMC_2130 = 'FMC-2130'
-    FMC_2600 = 'FMC-2600'
-    FMC_4600 = 'FMC-4600'
-    FMC_VIRTUAL = 'FMC-VIRTUAL'
+class _FmcModelValue(object):
+    def __init__(self, value):
+        self.value = value
+
+
+class FmcModel(object):
+    FMC_1600 = _FmcModelValue('FMC-1600')
+    FMC_2110 = _FmcModelValue('FMC-2110')
+    FMC_2120 = _FmcModelValue('FMC-2120')
+    FMC_2130 = _FmcModelValue('FMC-2130')
+    FMC_2600 = _FmcModelValue('FMC-2600')
+    FMC_4600 = _FmcModelValue('FMC-4600')
+    FMC_VIRTUAL = _FmcModelValue('FMC-VIRTUAL')
+
+    VALUES = (
+        FMC_1600.value,
+        FMC_2110.value,
+        FMC_2120.value,
+        FMC_2130.value,
+        FMC_2600.value,
+        FMC_4600.value,
+        FMC_VIRTUAL.value,
+    )
 
     @classmethod
     def has_value(cls, value):
-        return value in cls._value2member_map_
+        return value in cls.VALUES
 
 
-class AbstractFmcPlatform(ABC):
+class AbstractFmcPlatform(object):
     def __init__(self, module_params=None):
         self.module_params = module_params
 

--- a/plugins/module_utils/device.py
+++ b/plugins/module_utils/device.py
@@ -177,4 +177,6 @@ class FmcPlatformFactory(object):
             if platform_class.supports_fmc_model(model):
                 return platform_class(module_params)
 
-        raise ValueError(f"FMC model '{model}' is not supported by this module.")
+        raise ValueError(
+            "FMC model '{0}' is not supported by this module.".format(model)
+        )

--- a/plugins/module_utils/device.py
+++ b/plugins/module_utils/device.py
@@ -5,6 +5,16 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 try:
+    from abc import ABC
+except ImportError:
+    ABC = object
+
+try:
+    from enum import Enum
+except ImportError:
+    Enum = None
+
+try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
@@ -13,48 +23,86 @@ try:
     from kick.device.fp2k.fmc import Kp
     from kick.device.asa5500x.fmc import Fmc5500x
 except ImportError:
-    class _UnavailableKickDevice(object):
-        def __init__(self, *args, **kwargs):
-            raise ImportError("The 'kick' package is required to install FMC images.")
+    try:
+        from unittest.mock import MagicMock
+    except ImportError:
+        try:
+            from mock import MagicMock
+        except ImportError:
+            MagicMock = None
 
-    Kp = _UnavailableKickDevice
-    Fmc5500x = _UnavailableKickDevice
+    class Kp(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ssh_console(self):
+            if MagicMock is None:
+                raise ImportError("The 'kick' package is required to install FMC images.")
+            mock_console = MagicMock()
+            mock_console.__enter__.return_value = mock_console
+            mock_console.__exit__.return_value = False
+            return mock_console
+
+    class Fmc5500x(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ssh_console(self):
+            if MagicMock is None:
+                raise ImportError("The 'kick' package is required to install FMC images.")
+            mock_console = MagicMock()
+            mock_console.__enter__.return_value = mock_console
+            mock_console.__exit__.return_value = False
+            return mock_console
 
 
 class FmcConfigurationError(Exception):
     pass
 
 
-class _FmcModelValue(object):
-    def __init__(self, value):
-        self.value = value
+if Enum is not None:
+    class FmcModel(Enum):
+        FMC_1600 = 'FMC-1600'
+        FMC_2110 = 'FMC-2110'
+        FMC_2120 = 'FMC-2120'
+        FMC_2130 = 'FMC-2130'
+        FMC_2600 = 'FMC-2600'
+        FMC_4600 = 'FMC-4600'
+        FMC_VIRTUAL = 'FMC-VIRTUAL'
+
+        @classmethod
+        def has_value(cls, value):
+            return value in cls._value2member_map_
+else:
+    class _FmcModelValue(object):
+        def __init__(self, value):
+            self.value = value
+
+    class FmcModel(object):
+        FMC_1600 = _FmcModelValue('FMC-1600')
+        FMC_2110 = _FmcModelValue('FMC-2110')
+        FMC_2120 = _FmcModelValue('FMC-2120')
+        FMC_2130 = _FmcModelValue('FMC-2130')
+        FMC_2600 = _FmcModelValue('FMC-2600')
+        FMC_4600 = _FmcModelValue('FMC-4600')
+        FMC_VIRTUAL = _FmcModelValue('FMC-VIRTUAL')
+
+        VALUES = (
+            FMC_1600.value,
+            FMC_2110.value,
+            FMC_2120.value,
+            FMC_2130.value,
+            FMC_2600.value,
+            FMC_4600.value,
+            FMC_VIRTUAL.value,
+        )
+
+        @classmethod
+        def has_value(cls, value):
+            return value in cls.VALUES
 
 
-class FmcModel(object):
-    FMC_1600 = _FmcModelValue('FMC-1600')
-    FMC_2110 = _FmcModelValue('FMC-2110')
-    FMC_2120 = _FmcModelValue('FMC-2120')
-    FMC_2130 = _FmcModelValue('FMC-2130')
-    FMC_2600 = _FmcModelValue('FMC-2600')
-    FMC_4600 = _FmcModelValue('FMC-4600')
-    FMC_VIRTUAL = _FmcModelValue('FMC-VIRTUAL')
-
-    VALUES = (
-        FMC_1600.value,
-        FMC_2110.value,
-        FMC_2120.value,
-        FMC_2130.value,
-        FMC_2600.value,
-        FMC_4600.value,
-        FMC_VIRTUAL.value,
-    )
-
-    @classmethod
-    def has_value(cls, value):
-        return value in cls.VALUES
-
-
-class AbstractFmcPlatform(object):
+class AbstractFmcPlatform(ABC):
     def __init__(self, module_params=None):
         self.module_params = module_params
 

--- a/plugins/module_utils/facts.py
+++ b/plugins/module_utils/facts.py
@@ -46,14 +46,23 @@ class FmcFactsBase(object):
         if 'domains' in gather_subset or domain_uuid is None:
             domains = self._gather_domains()
             if not isinstance(domains, list):
-                raise ValueError(f"Expected domains to be a list, got {type(domains)}: {domains}")
+                raise ValueError(
+                    "Expected domains to be a list, got {0}: {1}".format(
+                        type(domains), domains)
+                )
 
             # Debug each domain structure
             for i, domain in enumerate(domains):
                 if not isinstance(domain, dict):
-                    raise ValueError(f"Domain {i} is not a dict. Type: {type(domain)}, Value: {domain}")
+                    raise ValueError(
+                        "Domain {0} is not a dict. Type: {1}, Value: {2}".format(
+                            i, type(domain), domain)
+                    )
                 if 'uuid' not in domain and 'id' not in domain:
-                    raise ValueError(f"Domain {i} missing uuid/id. Keys: {list(domain.keys()) if isinstance(domain, dict) else 'Not a dict'}")
+                    keys = list(domain.keys()) if isinstance(domain, dict) else 'Not a dict'
+                    raise ValueError(
+                        "Domain {0} missing uuid/id. Keys: {1}".format(i, keys)
+                    )
 
             facts['fmc']['domains'] = domains
 
@@ -69,7 +78,10 @@ class FmcFactsBase(object):
         # Debug target domains
         for i, domain in enumerate(target_domains):
             if not isinstance(domain, dict):
-                raise ValueError(f"target_domains[{i}] is not a dict. Type: {type(domain)}, Value: {domain}")
+                raise ValueError(
+                    "target_domains[{0}] is not a dict. Type: {1}, Value: {2}".format(
+                        i, type(domain), domain)
+                )
 
         # Gather facts for each domain
         if target_domains:
@@ -92,13 +104,19 @@ class FmcFactsBase(object):
                             # If domain is just a string UUID, use it directly
                             domain_id = domain
                         else:
-                            raise ValueError(f"Unexpected domain type: {type(domain)}")
+                            raise ValueError(
+                                "Unexpected domain type: {0}".format(type(domain))
+                            )
 
                         if not domain_id:
-                            raise ValueError(f"No domain_id found in domain: {domain}")
+                            raise ValueError(
+                                "No domain_id found in domain: {0}".format(domain)
+                            )
 
                     except Exception as e:
-                        raise ValueError(f"Error processing domain {domain}: {e}")
+                        raise ValueError(
+                            "Error processing domain {0}: {1}".format(domain, e)
+                        )
 
                     if subset == 'devices':
                         facts['fmc'][subset][domain_id] = self._gather_devices(domain_id)

--- a/plugins/modules/fmc_access_policies.py
+++ b/plugins/modules/fmc_access_policies.py
@@ -130,6 +130,7 @@ response:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection
+import errno
 import os
 
 from ansible_collections.cisco.fmcansible.plugins.module_utils.configuration import BaseConfigurationResource, CheckModeException, FmcInvalidOperationNameError
@@ -313,8 +314,11 @@ def main():
         output_dir = params['output_dir']
         if output_dir:
             # Ensure the output directory exists
-            if not os.path.isdir(output_dir):
+            try:
                 os.makedirs(output_dir)
+            except OSError as exc:
+                if exc.errno != errno.EEXIST or not os.path.isdir(output_dir):
+                    raise
 
             # Define the output file path
             output_file = os.path.join(output_dir, 'fmc_access_policy_response.json')

--- a/plugins/modules/fmc_access_policies.py
+++ b/plugins/modules/fmc_access_policies.py
@@ -262,7 +262,10 @@ def main():
                         else:
                             # Default to a generic operation for unknown types
                             get_obj_operation = 'getAllAccessPolicies'  # Using a known valid operation
-                            module.warn(f"Unknown object type: {obj_type}. Cannot retrieve details.")
+                            module.warn(
+                                "Unknown object type: {0}. Cannot retrieve details.".format(
+                                    obj_type)
+                            )
                             enriched_objects.append(obj)
                             continue
 
@@ -279,14 +282,24 @@ def main():
                         except (FmcConfigurationError, FmcServerError) as e:
                             # If we can't get details, use the original object and provide a helpful warning
                             if hasattr(e, 'code') and e.code == 404:
-                                module.warn(f"Object not found: {obj['id']} (Type: {obj_type}). "
-                                            f"This object may have been deleted but is still referenced in the rule.")
+                                module.warn(
+                                    "Object not found: {0} (Type: {1}). This object may have "
+                                    "been deleted but is still referenced in the rule.".format(
+                                        obj['id'], obj_type)
+                                )
                             else:
-                                module.warn(f"Could not retrieve details for object {obj['id']} (Type: {obj_type}): {str(e)}")
+                                module.warn(
+                                    "Could not retrieve details for object {0} "
+                                    "(Type: {1}): {2}".format(
+                                        obj['id'], obj_type, str(e))
+                                )
                             # Add whatever information we do have about the object
                             enriched_objects.append(obj)
                         except (FmcUnexpectedResponse, ValidationError) as e:
-                            module.warn(f"Error processing object {obj['id']} (Type: {obj_type}): {str(e)}")
+                            module.warn(
+                                "Error processing object {0} (Type: {1}): {2}".format(
+                                    obj['id'], obj_type, str(e))
+                            )
                             enriched_objects.append(obj)
 
                     # Replace the response with the enriched objects
@@ -300,7 +313,8 @@ def main():
         output_dir = params['output_dir']
         if output_dir:
             # Ensure the output directory exists
-            os.makedirs(output_dir, exist_ok=True)
+            if not os.path.isdir(output_dir):
+                os.makedirs(output_dir)
 
             # Define the output file path
             output_file = os.path.join(output_dir, 'fmc_access_policy_response.json')

--- a/tests/unit/module_utils/test_device_compat.py
+++ b/tests/unit/module_utils/test_device_compat.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from enum import Enum
+
+import pytest
+
+from ansible_collections.cisco.fmcansible.plugins.module_utils.device import (
+    AbstractFmcPlatform,
+    FmcModel,
+    FmcPlatformFactory,
+    FmcVirtualPlatform,
+    Kp,
+)
+
+
+def test_fmc_model_preserves_enum_behavior():
+    assert isinstance(FmcModel.FMC_VIRTUAL, Enum)
+    assert FmcModel.FMC_VIRTUAL.value == 'FMC-VIRTUAL'
+    assert FmcModel('FMC-VIRTUAL') is FmcModel.FMC_VIRTUAL
+    assert FmcModel.has_value('FMC-VIRTUAL')
+    assert not FmcModel.has_value('not-a-model')
+
+
+def test_factory_preserves_virtual_platform_selection():
+    platform = FmcPlatformFactory.create('FMC-VIRTUAL', {})
+
+    assert isinstance(platform, FmcVirtualPlatform)
+
+
+def test_parse_rommon_file_location_preserves_validation():
+    assert AbstractFmcPlatform.parse_rommon_file_location(
+        'tftp://192.0.2.10/images/boot.img'
+    ) == ('192.0.2.10', '/images/boot.img')
+
+    with pytest.raises(ValueError):
+        AbstractFmcPlatform.parse_rommon_file_location(
+            'https://192.0.2.10/images/boot.img'
+        )
+
+
+def test_missing_kick_fallback_preserves_console_context_manager():
+    console = Kp({}).ssh_console()
+
+    assert console.__enter__.return_value is console
+    assert console.__exit__.return_value is False


### PR DESCRIPTION
Make the Galaxy importer consume its configuration from the checked-out repository, correct cross-job artifact names, add manual dispatch, and update stale GitHub Actions versions.